### PR TITLE
workarounds - remove when dapr is moved to 0.6

### DIFF
--- a/feed-generator/Program.cs
+++ b/feed-generator/Program.cs
@@ -25,7 +25,7 @@ namespace FeedGenerator
         {
             int delayInMilliseconds = 10000;
             if (args.Length != 0)
-            {                
+            {
                 if (int.TryParse(args[0], out delayInMilliseconds) == false)
                 {
                     string msg = "Could not parse delay";
@@ -59,15 +59,24 @@ namespace FeedGenerator
             TimeSpan delay = TimeSpan.FromMilliseconds(delayInMilliseconds);
 
             DaprClientBuilder daprClientBuilder = new DaprClientBuilder();
-            DaprClient client = daprClientBuilder.Build();
-
+            
+            // workaround - remove "UseEndpoint("https://127.0.0.1:50001")" when dapr runtime moves to 0.6
+            DaprClient client = daprClientBuilder.UseEndpoint("https://127.0.0.1:50001").Build();
             while (true)
-            {
-                await Task.Delay(delay);
-
+            {              
                 SocialMediaMessage message = GeneratePost();
                 Console.WriteLine("Publishing");
-                await client.PublishEventAsync<SocialMediaMessage>(PubsubTopicName, message);                
+                try
+                {
+                    
+                    await client.PublishEventAsync<SocialMediaMessage>(PubsubTopicName, message);
+                }
+                catch (Exception e)
+                {                    
+                    Console.WriteLine("Caught {0}", e.ToString());
+                }
+
+                await Task.Delay(delay);
             }
         }
 

--- a/longhaul-test/feed-generator-deploy.yml
+++ b/longhaul-test/feed-generator-deploy.yml
@@ -20,9 +20,8 @@ spec:
         app: feed-generator
       annotations:
         dapr.io/enabled: "true"
-        dapr.io/id: "feed-generator"
-        dapr.io/port: "3000"
-        dapr.io/log-as-json: "true"
+        dapr.io/id: "feed-generator"        
+        dapr.io/log-as-json: "true"                 
     spec:
       containers:
       - name: feed-generator

--- a/longhaul-test/message-analyzer-deploy.yml
+++ b/longhaul-test/message-analyzer-deploy.yml
@@ -21,12 +21,12 @@ spec:
       annotations:
         dapr.io/enabled: "true"
         dapr.io/id: "message-analyzer"
-        dapr.io/port: "3000"
+        dapr.io/port: "80"
         dapr.io/log-as-json: "true"
     spec:
       containers:
       - name: message-analyzer
         image: dapriotest/message-analyzer:dev
         ports:
-        - containerPort: 3000
+        - containerPort: 80
         imagePullPolicy: Always

--- a/message-analyzer/Program.cs
+++ b/message-analyzer/Program.cs
@@ -7,6 +7,7 @@ namespace MessageAnalyzer
 {
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Hosting;
+    using System;
 
     /// <summary>
     /// MessageAnalyzer - receives messages from Dapr through pub/sub, adds a 
@@ -20,6 +21,7 @@ namespace MessageAnalyzer
         /// <param name="args">Arguments.</param>
         public static void Main(string[] args)
         {
+            Console.WriteLine("Enter main");
             CreateHostBuilder(args).Build().Run();
         }
 

--- a/message-analyzer/Properties/launchSettings.json
+++ b/message-analyzer/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:52186/",
+      "applicationUrl": "http://localhost:80/",
       "sslPort": 0
     }
   },
@@ -21,7 +21,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:3000/"
+      "applicationUrl": "http://localhost:80/"
     }
   }
 }

--- a/message-analyzer/Startup.cs
+++ b/message-analyzer/Startup.cs
@@ -60,7 +60,8 @@ namespace MessageAnalyzer
         /// <param name="services">Service Collection.</param>
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddDaprClient();
+            // workaround.  remove when dapr runtime is 0.6
+            services.AddDaprClient((b) => b.UseEndpoint("https://127.0.0.1:50001"));
 
             services.AddSingleton(new JsonSerializerOptions()
             {


### PR DESCRIPTION
Use workarounds for mtls enabled endpoints.  This can be removed when the runtime moves to 0.6