### PR TITLE
Add telemetry in apps

### DIFF
--- a/feed-generator/Program.cs
+++ b/feed-generator/Program.cs
@@ -18,9 +18,9 @@ namespace FeedGenerator
     /// </summary>
     public class Program
     {
-        private static readonly Gauge PublishCallTime = Metrics.CreateGauge("feed_generator_publish_call_time", "The time it takes for the publish call to return");
+        private static readonly Gauge PublishCallTime = Metrics.CreateGauge("lh_feed_generator_publish_call_time", "The time it takes for the publish call to return");
 
-        private static readonly Counter PublishFailureCount = Metrics.CreateCounter("feed_generator_publish_failure_count", "Publich calls that throw");
+        private static readonly Counter PublishFailureCount = Metrics.CreateCounter("lh_feed_generator_publish_failure_count", "Publich calls that throw");
 
         // This uses the names of shapes for a generic theme
         static internal string[] HashTags = new string[]

--- a/feed-generator/SocialMediaMessage.cs
+++ b/feed-generator/SocialMediaMessage.cs
@@ -20,5 +20,9 @@ namespace FeedGenerator
         public DateTime CreationDate { get; set; }
 
         public string Sentiment { get; set; }
+
+        // Used to measure the time between apps which is reported as a metric.  
+        // An app should overwrite this if it wants a later one to measure duration.
+        public DateTime PreviousAppTimestamp { get; set; }
     }
 }

--- a/feed-generator/feed-generator.csproj
+++ b/feed-generator/feed-generator.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Dapr.AspNetCore" Version="0.5.0-preview02" />
     <PackageReference Include="Dapr.Client" Version="0.5.0-preview02" />
+    <PackageReference Include="prometheus-net" Version="3.5.0" />
   </ItemGroup>
 
 </Project>

--- a/hashtag-actor/hashtag-actor.csproj
+++ b/hashtag-actor/hashtag-actor.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Dapr.Actors" Version="0.6.0-preview01" />
     <PackageReference Include="Dapr.Actors.AspNetCore" Version="0.6.0-preview01" />
+    <PackageReference Include="prometheus-net" Version="3.5.0" />
   </ItemGroup>
 
 </Project>

--- a/hashtag-counter/Controllers/HashTagController.cs
+++ b/hashtag-counter/Controllers/HashTagController.cs
@@ -21,7 +21,7 @@ namespace Dapr.Tests.HashTagApp.Controllers
     [Produces(MediaTypeNames.Application.Json)]
     public class HashTagController : ControllerBase
     {
-        private static readonly Gauge BindingDuration = Metrics.CreateGauge("hashtag_counter_binding_duration_in_ms", "The time between the previous app's binding call and the time this app receives it");
+        private static readonly Gauge BindingDuration = Metrics.CreateGauge("lh_hashtag_counter_binding_duration_in_ms", "The time between the previous app's binding call and the time this app receives it");
 
         private readonly IConfiguration configuration;
 

--- a/hashtag-counter/Controllers/HashTagController.cs
+++ b/hashtag-counter/Controllers/HashTagController.cs
@@ -12,6 +12,7 @@ namespace Dapr.Tests.HashTagApp.Controllers
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
+    using Prometheus;
     using System;
     using System.Net.Mime;
     using System.Threading.Tasks;
@@ -20,11 +21,13 @@ namespace Dapr.Tests.HashTagApp.Controllers
     [Produces(MediaTypeNames.Application.Json)]
     public class HashTagController : ControllerBase
     {
+        private static readonly Gauge BindingDuration = Metrics.CreateGauge("hashtag_counter_binding_duration_in_ms", "The time between the previous app's binding call and the time this app receives it");
+
         private readonly IConfiguration configuration;
 
-        public HashTagController( IConfiguration config)
+        public HashTagController(IConfiguration config)
         {
-            Console.WriteLine("ctor.");           
+            Console.WriteLine("ctor.");
             this.configuration = config;
         }
 
@@ -32,6 +35,9 @@ namespace Dapr.Tests.HashTagApp.Controllers
         public async Task<IActionResult> PostMessageBinding([FromBody]SocialMediaMessage message)
         {
             Console.WriteLine("enter messagebinding");
+
+            var duration = DateTime.UtcNow - message.PreviousAppTimestamp;
+            BindingDuration.Set(duration.TotalSeconds);
 
             Console.WriteLine($"{message.CreationDate}, {message.CorrelationId}, {message.MessageId}, {message.Message}, {message.Sentiment}");
 

--- a/hashtag-counter/Models/SocialMediaMessage.cs
+++ b/hashtag-counter/Models/SocialMediaMessage.cs
@@ -20,5 +20,10 @@ namespace Dapr.Tests.HashTagApp.Models
         public string Sentiment { get; set; }
         [Required]
         public DateTime CreationDate { get; set; }
+
+        // Used to measure the time between apps which is reported as a metric.  
+        // An app should overwrite this if it wants a later one to measure duration.
+        [Required]
+        public DateTime PreviousAppTimestamp { get; set; }
     }
 }

--- a/hashtag-counter/Program.cs
+++ b/hashtag-counter/Program.cs
@@ -13,11 +13,16 @@ namespace Dapr.Tests.HashTagApp
     using Microsoft.Extensions.Logging;
     using Dapr.Actors.AspNetCore;
     using Dapr.Tests.HashTagApp.Actors;
+    using Prometheus;
 
     public class Program
     {
         public static void Main(string[] args)
         {
+            var server = new MetricServer(port: 9988);
+            server.Start();
+
+           
             CreateHostBuilder(args).Build().Run();
         }
 

--- a/hashtag-counter/hashtag-counter.csproj
+++ b/hashtag-counter/hashtag-counter.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Dapr.Actors" Version="0.6.0-preview01" />
     <PackageReference Include="Dapr.Actors.AspNetCore" Version="0.6.0-preview01" />
+    <PackageReference Include="prometheus-net" Version="3.5.0" />
   </ItemGroup>
 
 </Project>

--- a/longhaul-test/feed-generator-deploy.yml
+++ b/longhaul-test/feed-generator-deploy.yml
@@ -3,6 +3,22 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
+kind: Service
+apiVersion: v1
+metadata:
+  name: feed-generator
+  labels:
+    app: feed-generator
+spec:
+  selector:
+    app: feed-generator
+  ports:
+  - protocol: TCP
+    port: 9988
+    targetPort: 9988
+  type: ClusterIP
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20,12 +36,18 @@ spec:
         app: feed-generator
       annotations:
         dapr.io/enabled: "true"
-        dapr.io/id: "feed-generator"        
-        dapr.io/log-as-json: "true"                 
+        dapr.io/id: "feed-generator"
+        dapr.io/log-as-json: "true"
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9988'        
     spec:
       containers:
       - name: feed-generator
         image: dapriotest/feed-generator:dev
-        ports:
-        - containerPort: 3000
+        ports:        
+        - name: dapp
+          containerPort: 3000
+        - name: prom
+          containerPort: 9988
+          
         imagePullPolicy: Always

--- a/longhaul-test/hashtag-counter-deploy.yml
+++ b/longhaul-test/hashtag-counter-deploy.yml
@@ -3,6 +3,22 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
+kind: Service
+apiVersion: v1
+metadata:
+  name: hashtag-counter
+  labels:
+    app: hashtag-counter
+spec:
+  selector:
+    app: hashtag-counter
+  ports:
+  - protocol: TCP
+    port: 9988
+    targetPort: 9988
+  type: ClusterIP
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23,10 +39,13 @@ spec:
         dapr.io/id: "hashtag-counter"
         dapr.io/port: "3000"
         dapr.io/log-as-json: "true"
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9988'  
     spec:
       containers:
       - name: hashtag-counter
         image: dapriotest/hashtag-counter:dev
         ports:
         - containerPort: 3000
+        - containerPort: 9988
         imagePullPolicy: Always

--- a/longhaul-test/message-analyzer-deploy.yml
+++ b/longhaul-test/message-analyzer-deploy.yml
@@ -3,6 +3,22 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
+kind: Service
+apiVersion: v1
+metadata:
+  name: message-analyzer
+  labels:
+    app: message-analyzer
+spec:
+  selector:
+    app: message-analyzer
+  ports:
+  - protocol: TCP
+    port: 9988
+    targetPort: 9988
+  type: ClusterIP
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23,10 +39,13 @@ spec:
         dapr.io/id: "message-analyzer"
         dapr.io/port: "80"
         dapr.io/log-as-json: "true"
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9988'        
     spec:
       containers:
       - name: message-analyzer
         image: dapriotest/message-analyzer:dev
         ports:
         - containerPort: 80
+        - containerPort: 9988
         imagePullPolicy: Always

--- a/longhaul-test/snapshot-deploy.yml
+++ b/longhaul-test/snapshot-deploy.yml
@@ -3,6 +3,22 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
+kind: Service
+apiVersion: v1
+metadata:
+  name: snapshot
+  labels:
+    app: snapshot
+spec:
+  selector:
+    app: snapshot
+  ports:
+  - protocol: TCP
+    port: 9988
+    targetPort: 9988
+  type: ClusterIP
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23,12 +39,15 @@ spec:
         dapr.io/id: "snapshot"
         dapr.io/port: "3000"
         dapr.io/log-as-json: "true"
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9988'        
     spec:
       containers:
       - name: snapshot
         image: dapriotest/snapshot:dev
         ports:
         - containerPort: 3000
+        - containerPort: 9988
         imagePullPolicy: Always
         env:
         - name: DELAY_IN_MS

--- a/message-analyzer/Program.cs
+++ b/message-analyzer/Program.cs
@@ -7,6 +7,7 @@ namespace MessageAnalyzer
 {
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Hosting;
+    using Prometheus;
     using System;
 
     /// <summary>
@@ -22,6 +23,10 @@ namespace MessageAnalyzer
         public static void Main(string[] args)
         {
             Console.WriteLine("Enter main");
+
+            var server = new MetricServer(port: 9988);
+            server.Start();
+
             CreateHostBuilder(args).Build().Run();
         }
 

--- a/message-analyzer/SocialMediaMessage.cs
+++ b/message-analyzer/SocialMediaMessage.cs
@@ -20,5 +20,9 @@ namespace MessageAnalyzer
         public DateTime CreationDate { get; set; }
 
         public string Sentiment { get; set; }
+
+        // Used to measure the time between apps which is reported as a metric.  
+        // An app should overwrite this if it wants a later one to measure duration.
+        public DateTime PreviousAppTimestamp { get; set; }
     }
 }

--- a/message-analyzer/Startup.cs
+++ b/message-analyzer/Startup.cs
@@ -23,9 +23,9 @@ namespace MessageAnalyzer
     /// </summary>
     public class Startup
     {
-        private static readonly Gauge PubSubDuration = Metrics.CreateGauge("message_analyzer_pubsub_duration", "The time between the previous app's publish call and the time this app receives it");
+        private static readonly Gauge PubSubDuration = Metrics.CreateGauge("lh_message_analyzer_pubsub_duration", "The time between the previous app's publish call and the time this app receives it");
 
-        private static readonly Gauge OutputBindingCallTime = Metrics.CreateGauge("message_analyzer_output_binding_call_time", "The time it takes the binding api to return locally");
+        private static readonly Gauge OutputBindingCallTime = Metrics.CreateGauge("lh_message_analyzer_output_binding_call_time", "The time it takes the binding api to return locally");
 
         private static string[] Sentiments = new string[]
         {

--- a/message-analyzer/Startup.cs
+++ b/message-analyzer/Startup.cs
@@ -6,12 +6,14 @@
 namespace MessageAnalyzer
 {
     using Dapr.Client;
+    using Google.Protobuf.WellKnownTypes;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
+    using Prometheus;
     using System;
     using System.Text.Json;
     using System.Threading.Tasks;
@@ -21,6 +23,10 @@ namespace MessageAnalyzer
     /// </summary>
     public class Startup
     {
+        private static readonly Gauge PubSubDuration = Metrics.CreateGauge("message_analyzer_pubsub_duration", "The time between the previous app's publish call and the time this app receives it");
+
+        private static readonly Gauge OutputBindingCallTime = Metrics.CreateGauge("message_analyzer_output_binding_call_time", "The time it takes the binding api to return locally");
+
         private static string[] Sentiments = new string[]
         {
             "verynegative",
@@ -59,7 +65,7 @@ namespace MessageAnalyzer
         /// </summary>
         /// <param name="services">Service Collection.</param>
         public void ConfigureServices(IServiceCollection services)
-        {            
+        {
             services.AddDaprClient();
 
             services.AddSingleton(new JsonSerializerOptions()
@@ -101,10 +107,21 @@ namespace MessageAnalyzer
 
                 var message = await JsonSerializer.DeserializeAsync<SocialMediaMessage>(context.Request.Body, serializerOptions);
 
+                // record the time
+                TimeSpan durationFromPreviousApp = DateTime.UtcNow - message.PreviousAppTimestamp;                
+                PubSubDuration.Set(durationFromPreviousApp.TotalSeconds);
+
                 // update with a sentiment
                 message.Sentiment = GenerateRandomSentiment();
                 Console.WriteLine($"....Invoking binding {BindingName} with message {message.Message} and sentiment {message.Sentiment}");
-                await client.InvokeBindingAsync<SocialMediaMessage>(BindingName, message);
+
+                // overwrite the timestamp so the next app can use it
+                message.PreviousAppTimestamp = DateTime.UtcNow;
+
+                using (OutputBindingCallTime.NewTimer())
+                {
+                    await client.InvokeBindingAsync<SocialMediaMessage>(BindingName, message);
+                }
             }
         }
 

--- a/message-analyzer/message-analyzer.csproj
+++ b/message-analyzer/message-analyzer.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Dapr.AspNetCore" Version="0.5.0-preview02" />
     <PackageReference Include="Dapr.Client" Version="0.5.0-preview02" />
+    <PackageReference Include="prometheus-net" Version="3.5.0" />
   </ItemGroup>
 
 </Project>

--- a/snapshot/Program.cs
+++ b/snapshot/Program.cs
@@ -21,9 +21,9 @@ namespace Dapr.Tests.Snapshot
 
     public class Program
     {
-        private static readonly Gauge DelaySinceLastSnapShot = Metrics.CreateGauge("snapshot_actor_delay_since_last_snapshot", "The time since the last round of snapshots");
+        private static readonly Gauge DelaySinceLastSnapShot = Metrics.CreateGauge("lh_snapshot_actor_delay_since_last_snapshot", "The time since the last round of snapshots");
 
-        private static readonly Gauge ActorMethodCallTime = Metrics.CreateGauge("snapshot_actor_method_call_time", "The time it takes for the GetCount actor method to return");
+        private static readonly Gauge ActorMethodCallTime = Metrics.CreateGauge("lh_snapshot_actor_method_call_time", "The time it takes for the GetCount actor method to return");
         
         // This uses the names of shapes for a generic theme
         static internal string[] HashTags = new string[]

--- a/snapshot/snapshot.csproj
+++ b/snapshot/snapshot.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Dapr.Actors.AspNetCore" Version="0.6.0-preview01" />
     <PackageReference Include="Dapr.AspNetCore" Version="0.6.0-preview01" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
+    <PackageReference Include="prometheus-net" Version="3.5.0" />
 
   </ItemGroup>
 


### PR DESCRIPTION
# Description

This instruments the apps to export metrics to prometheus using prometheus-net.  The current metrics are mostly related to durations of calls or the time between apps sending and receiving data.  

I tried using opentelemetry-dotnet earlier, but it looks like that one is missing functionality, such as gauges, at the moment.

These metrics will be used for validation and alerting in subsequent changes.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Maps approx to #8, #9, #10.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
