### PR TITLE
Delete keyvault cert secret before creating

### DIFF
--- a/.github/workflows/pubsub-workflow-build.yml
+++ b/.github/workflows/pubsub-workflow-build.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Set up azure keyvault certificate secret
         run: |
           az keyvault secret download --vault-name longhaul-kv --name longhaul-cert --encoding base64 --file longhaul-cert.pfx
+          kubectl delete secret longhaulcert --ignore-not-found
           kubectl create secret generic longhaulcert --from-file=longhaulcert=./longhaul-cert.pfx
       - name: Deploy apps to longhaul test environment
         run: |


### PR DESCRIPTION
# Description
Creating a secret fails if it is already present. This commit deletes
the secret first before creating it. We chose to do this instead of
just not creating it if present as it allows for the cert to be
changed without manual intervention.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close:N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
