### PR TITLE
Keep reference to publishing Timer

### DIFF
--- a/longhaul-test/binding.yaml
+++ b/longhaul-test/binding.yaml
@@ -10,6 +10,7 @@ metadata:
   namespace: longhaul-test
 spec:
   type: bindings.kafka
+  version: v1
   metadata:
   # Kafka broker connection setting
   - name: brokers

--- a/longhaul-test/redis-pubsub.yaml
+++ b/longhaul-test/redis-pubsub.yaml
@@ -10,6 +10,7 @@ metadata:
   namespace: longhaul-test
 spec:
   type: pubsub.redis
+  version: v1
   metadata:
   - name: redisHost
     value: dapr-redis-master.dapr-components.svc.cluster.local:6379

--- a/longhaul-test/redis-statestore.yaml
+++ b/longhaul-test/redis-statestore.yaml
@@ -10,6 +10,7 @@ metadata:
   namespace: longhaul-test
 spec:
   type: state.redis
+  version: v1
   metadata:
   - name: redisHost
     value: dapr-redis-master.dapr-components.svc.cluster.local:6379


### PR DESCRIPTION
# Description
Without the reference to the publishing timer, it can be garbage
collected despite the fact that it's running. We believe this to
be the cause of the publisher stopping after ~30 minutes.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
