### PR TITLE
Update component secrets and add actor statestore

### DIFF
--- a/.github/workflows/dapr-longhaul-nightly.yml
+++ b/.github/workflows/dapr-longhaul-nightly.yml
@@ -168,7 +168,7 @@ jobs:
           kubectl apply -f ./longhaul-test/azure-service-bus-pubsub.yml -n ${{ env.APP_NAMESPACE }}
           kubectl apply -f ./longhaul-test/azure-storagequeue-binding.yaml -n ${{ env.APP_NAMESPACE }}
           kubectl apply -f ./longhaul-test/redis-pubsub.yaml -n ${{ env.APP_NAMESPACE }}
-          kubectl apply -f ./longhaul-test/azure-blob-statestore.yaml -n ${{ env.APP_NAMESPACE }}
+          kubectl apply -f ./longhaul-test/azure-cosmosdb-statestore.yaml -n ${{ env.APP_NAMESPACE }}
       - name: Deploy test applications
         if: env.TEST_CLUSTER != ''
         working-directory: ./longhaul

--- a/longhaul-test/azure-blob-statestore.yaml
+++ b/longhaul-test/azure-blob-statestore.yaml
@@ -3,10 +3,12 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
+# Not currently in use by the longhauls but kept present in case we want to switch stores.
+# Note: Cannot be used for actors!
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: statestore
+  name: blobstore
   namespace: longhaul-test
 spec:
   type: state.azure.blobstorage
@@ -18,8 +20,8 @@ spec:
         key: AzureStorageAccount
     - name: accountKey
       secretKeyRef:
-        name: AzureStorageAccount
-        key: AzureStorageAccount
+        name: AzureStorageAccountKey
+        key: AzureStorageAccountKey
     - name: containerName
       secretKeyRef:
         name: AzureStorageContainer

--- a/longhaul-test/azure-cosmosdb-statestore.yaml
+++ b/longhaul-test/azure-cosmosdb-statestore.yaml
@@ -1,0 +1,30 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+  namespace: longhaul-test
+spec:
+  type: state.azure.cosmosdb
+  version: v1
+  metadata:
+  - name: url
+    secretKeyRef:
+      name: CosmosUrl
+      key: CosmosUrl
+  - name: masterKey
+    secretKeyRef:
+      name: CosmosMasterKey
+      key: CosmosMasterKey
+  # Use secrets to point standard/nightly longhauls at different dbs/collections.
+  - name: database 
+    secretKeyRef:
+      name: CosmosDatabase
+      key: CosmosDatabase
+  - name: collection
+    secretKeyRef:
+      name: CosmosCollection
+      key: CosmosCollection
+  - name: actorStateStore
+    value: "true"
+auth:
+  secretStore: longhaul-kv

--- a/longhaul-test/azure-storagequeue-binding.yaml
+++ b/longhaul-test/azure-storagequeue-binding.yaml
@@ -14,15 +14,15 @@ spec:
   metadata:
     - name: storageAccount
       secretKeyRef:
-          name: AzureStorageAccount
-          key: AzureStorageAccount
+        name: AzureStorageAccount
+        key: AzureStorageAccount
     - name: storageAccessKey
       secretKeyRef:
-          name: AzureStorageAccount
-          key: AzureStorageAccessKey
+        name: AzureStorageAccountKey
+        key: AzureStorageAccountKey
     - name: queue
       secretKeyRef:
-          name: AzureStorageQueue
-          key: AzureStorageQueue
+        name: AzureStorageQueue
+        key: AzureStorageQueue
 auth:
   secretStore: longhaul-kv


### PR DESCRIPTION
# Description

The component secrets were not referencing the correct keys and
we had removed our actor statestore. This fix addresses the secrets
and moves us from blobstore to cosmosdb as it can be used for actors.

Tested manually by bringing the nightly longhauls back up to date.

```
➜  ~/Workspace/test-infra git:(master) 
$ kubectl get pods -n longhaul-test
NAME                                     READY   STATUS    RESTARTS   AGE
feed-generator-app-566f4cb657-dvzv6      2/2     Running   0          39m
hashtag-actor-app-5c5f7d9bd6-pqcm4       2/2     Running   0          16m
hashtag-counter-app-5865c5f57-8phlg      2/2     Running   0          7m25s
message-analyzer-app-6b6b476b58-nvnk9    2/2     Running   0          39m
pubsub-workflow-app-68c55467f5-t7csm     2/2     Running   0          15s
snapshot-app-7bd97ff986-v8cp8            2/2     Running   0          16m
validation-worker-app-567bd6d88c-g5lbk   2/2     Running   0          39m
```

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: NA

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
