### PR TITLE
Move Azure Keyvault to Service Principal Auth

### DIFF
--- a/longhaul-test/azure-keyvault.yml
+++ b/longhaul-test/azure-keyvault.yml
@@ -9,13 +9,13 @@ spec:
   metadata:
   - name: vaultName
     value: longhaul-kv
-  - name: spnTenantId
+  - name: azureTenantId
     value: "72f988bf-86f1-41af-91ab-2d7cd011db47"
-  - name: spnClientId
+  - name: azureClientId
     value: "b5a57d13-8326-40b1-939f-41384ad68781"
-  - name: spnCertificate
+  - name: azureClientSecret
     secretKeyRef:
-      name: longhaulcert
-      key: longhaulcert
+      name: longhaulclientsecret
+      key: clientsecret
 auth:
   secretStore: kubernetes


### PR DESCRIPTION
# Description

The certificate for the keyvault expired so I moved it to Service Principal based auth since that's the recommended path anyway.

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: NA

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
