### PR TITLE
Allow for manual runs of nightly workflow

### DIFF
--- a/.github/workflows/dapr-longhaul-nightly.yml
+++ b/.github/workflows/dapr-longhaul-nightly.yml
@@ -16,6 +16,7 @@ name: dapr-longhaul-nightly
 on:
   schedule:
    - cron: '0 7 * * *'
+  workflow_dispatch:
 
 jobs:
   test-nightly:


### PR DESCRIPTION
# Description

Allows the nightly workflow to be dispatched manually so we can run it to refresh the nightly cluster.

Signed-off-by: halspang <70976921+halspang@users.noreply.github.com>

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: NA

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
