### PR TITLE
Split servicebus component into three separate components

### DIFF
--- a/longhaul-test/azure-service-bus-pubsub.yml
+++ b/longhaul-test/azure-service-bus-pubsub.yml
@@ -6,7 +6,7 @@
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: longhaul-sb
+  name: longhaul-sb-rapid
   namespace: longhaul-test
 spec:
   type: pubsub.azure.servicebus
@@ -18,3 +18,55 @@ spec:
       key: sb-conn
 auth:
   secretStore: longhaul-kv
+
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: longhaul-sb-medium
+  namespace: longhaul-test
+spec:
+  type: pubsub.azure.servicebus
+  version: v1
+  metadata:
+  - name: connectionString
+    secretKeyRef:
+      name: sb-conn
+      key: sb-conn
+auth:
+  secretStore: longhaul-kv
+
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: longhaul-sb-slow
+  namespace: longhaul-test
+spec:
+  type: pubsub.azure.servicebus
+  version: v1
+  metadata:
+  - name: connectionString
+    secretKeyRef:
+      name: sb-conn
+      key: sb-conn
+auth:
+  secretStore: longhaul-kv
+
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: longhaul-sb-glacial
+  namespace: longhaul-test
+spec:
+  type: pubsub.azure.servicebus
+  version: v1
+  metadata:
+  - name: connectionString
+    secretKeyRef:
+      name: sb-conn
+      key: sb-conn
+auth:
+  secretStore: longhaul-kv
+

--- a/pubsub-workflow/Controllers/PubsubController.cs
+++ b/pubsub-workflow/Controllers/PubsubController.cs
@@ -17,8 +17,9 @@ namespace PubsubWorkflow
         internal static DateTime lastRapidCall = DateTime.Now;
         internal static DateTime lastMediumCall = DateTime.Now;
         internal static DateTime lastSlowCall = DateTime.Now;
+        internal static DateTime lastGlacialCall = DateTime.Now;
 
-        [Topic("longhaul-sb", "rapidtopic")]
+        [Topic("longhaul-sb-rapid", "rapidtopic")]
         [HttpPost("rapidMessage")]
         public IActionResult RapidMessageHandler() {
             var lastHit = lastRapidCall;
@@ -27,7 +28,7 @@ namespace PubsubWorkflow
             return Ok();
         }
 
-        [Topic("longhaul-sb", "mediumtopic")]
+        [Topic("longhaul-sb-medium", "mediumtopic")]
         [HttpPost("mediumMessage")]
         public IActionResult MediumMessageHandler() {
             var lastHit = lastMediumCall;
@@ -36,12 +37,21 @@ namespace PubsubWorkflow
             return Ok();
         }
 
-        [Topic("longhaul-sb", "slowtopic")]
+        [Topic("longhaul-sb-slow", "slowtopic")]
         [HttpPost("slowMessage")]
         public IActionResult SlowMessageHandler() {
             var lastHit = lastSlowCall;
             lastSlowCall = DateTime.Now;
             Console.WriteLine($"Slow subscription hit at {lastSlowCall}, previous hit at {lastHit}");
+            return Ok();
+        }
+        
+        [Topic("longhaul-sb-glacial", "glacialtopic")]
+        [HttpPost("glacialMessage")]
+        public IActionResult GlacialMessageHandler() {
+            var lastHit = lastGlacialCall;
+            lastGlacialCall = DateTime.Now;
+            Console.WriteLine($"Glacial subscription hit at {lastGlacialCall}, previous hit at {lastHit}");
             return Ok();
         }
     }

--- a/pubsub-workflow/Program.cs
+++ b/pubsub-workflow/Program.cs
@@ -16,9 +16,13 @@ using System.Threading.Tasks;
 
 namespace PubsubWorkflow
 {
+    
     class PubsubWorkflow
     {
-        private static string pubsubName = "longhaul-sb";
+        private static string rapidPubsubName = "longhaul-sb-rapid";
+        private static string mediumPubsubName = "longhaul-sb-medium";
+        private static string slowPubsubName = "longhaul-sb-slow";
+        private static string glacialPubsubName = "longhaul-sb-glacial";
 
         static void Main(string[] args)
         {
@@ -29,9 +33,10 @@ namespace PubsubWorkflow
 
             var host = CreateHostBuilder(args).Build();
 
-            var rapidTimer = StartPublishingMessages(10, pubsubName, "rapidtopic");
-            var mediumTimer = StartPublishingMessages(300, pubsubName, "mediumtopic");
-            var slowTimer = StartPublishingMessages(3600, pubsubName, "slowtopic");
+            var rapidTimer = StartPublishingMessages(10, rapidPubsubName, "rapidtopic");
+            var mediumTimer = StartPublishingMessages(300, mediumPubsubName, "mediumtopic");
+            var slowTimer = StartPublishingMessages(3600, slowPubsubName, "slowtopic");
+            var glacialTimer = StartPublishingMessages(3600*12, glacialPubsubName, "glacialtopic");
             
             host.Run();
 
@@ -40,6 +45,7 @@ namespace PubsubWorkflow
             rapidTimer.Dispose();
             mediumTimer.Dispose();
             slowTimer.Dispose();
+            glacialTimer.Dispose();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>


### PR DESCRIPTION
The current implementation uses the same component for all the topics so I believe that, even though we have a "slow" channel its connection is shared with the "rapid" channel, connectivity issues due to idle components would not manifest themselves in the current state. 

## Issue reference

This change aims to catch behavior where idle connections misbehave and lead to problems (potential cause of dapr/dapr#5621)

