### PR TITLE
Bump Dapr to 1.10.0-rc.2 and .NET to 1.10.0-rc01

### DIFF
--- a/.github/workflows/dapr-deploy.yml
+++ b/.github/workflows/dapr-deploy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
-      DAPR_RUNTIME_VER: 1.9.0-rc.6
+      DAPR_RUNTIME_VER: 1.10.0-rc.2
       DAPR_NAMESPACE: dapr-system
       TEST_CLUSTER_NAME: dapr-release-longhaul
       TEST_RESOURCE_GROUP: dapr-test

--- a/feed-generator/feed-generator.csproj
+++ b/feed-generator/feed-generator.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.9.0-rc01" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.10.0-rc01" />
     <PackageReference Include="prometheus-net" Version="3.5.0" />
   </ItemGroup>
 

--- a/hashtag-actor/hashtag-actor.csproj
+++ b/hashtag-actor/hashtag-actor.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.Actors.AspNetCore" Version="1.9.0-rc01" />
+    <PackageReference Include="Dapr.Actors.AspNetCore" Version="1.10.0-rc01" />
     <PackageReference Include="prometheus-net" Version="3.5.0" />
   </ItemGroup>
 

--- a/hashtag-counter/hashtag-counter.csproj
+++ b/hashtag-counter/hashtag-counter.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.Actors.AspNetCore" Version="1.9.0-rc01" />
+    <PackageReference Include="Dapr.Actors.AspNetCore" Version="1.10.0-rc01" />
     <PackageReference Include="prometheus-net" Version="3.5.0" />
   </ItemGroup>
 

--- a/message-analyzer/message-analyzer.csproj
+++ b/message-analyzer/message-analyzer.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.9.0-rc01" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.10.0-rc01" />
     <PackageReference Include="prometheus-net" Version="3.5.0" />
   </ItemGroup>
 

--- a/pubsub-workflow/pubsub-workflow.csproj
+++ b/pubsub-workflow/pubsub-workflow.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.9.0-rc01" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.10.0-rc01" />
     <PackageReference Include="prometheus-net" Version="3.5.0" />
   </ItemGroup>
 

--- a/snapshot/snapshot.csproj
+++ b/snapshot/snapshot.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.Actors.AspNetCore" Version="1.9.0-rc01" />
-    <PackageReference Include="Dapr.AspNetCore" Version="1.9.0-rc01" />
+    <PackageReference Include="Dapr.Actors.AspNetCore" Version="1.10.0-rc01" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.10.0-rc01" />
     <PackageReference Include="prometheus-net" Version="3.5.0" />
 
   </ItemGroup>

--- a/validation-worker/validation-worker.csproj
+++ b/validation-worker/validation-worker.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.9.0-rc01" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.10.0-rc01" />
     <PackageReference Include="prometheus-net" Version="3.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
# Description

As part of the 1.10 release process, we need to upgrade Dapr and .Net SDK version to their latest 1.10 version.

* Dapr: https://github.com/dapr/dapr/tree/v1.10.0-rc.2
* .Net SDK: https://github.com/dapr/dotnet-sdk/tree/v1.10.0-rc01

See dapr/dapr#5798

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
