### PR TITLE
Bump Dapr to 1.10.0-rc.9

### DIFF
--- a/.github/workflows/dapr-deploy.yml
+++ b/.github/workflows/dapr-deploy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
-      DAPR_RUNTIME_VER: 1.10.0-rc.8
+      DAPR_RUNTIME_VER: 1.10.0-rc.9
       DAPR_NAMESPACE: dapr-system
       TEST_CLUSTER_NAME: dapr-release-longhaul
       TEST_RESOURCE_GROUP: dapr-test


### PR DESCRIPTION
# Description

Upgrading Dapr to its latest 1.10 release candidate.

* Dapr: https://github.com/dapr/dapr/tree/v1.10.0-rc.9


## Issue reference

See dapr/dapr#5798

Adds dapr/dapr#5929


Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
