### PR TITLE
Bump nightly to Go 1.20

### DIFF
--- a/.github/workflows/dapr-longhaul-nightly.yml
+++ b/.github/workflows/dapr-longhaul-nightly.yml
@@ -23,7 +23,7 @@ jobs:
     name: update dapr runtime
     runs-on: ubuntu-latest
     env:
-      GOVER: 1.19
+      GOVER: 1.20
       KUBECTLVER: v1.19.3
       GOOS: linux
       GOARCH: amd64


### PR DESCRIPTION
# Description

Components contrib requires Go 1.20, this bumps the Go version for the nightly build.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: NA

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
