### PR TITLE
Bump dapr and dotnet sdk to 1.11 rcs

### DIFF
--- a/.github/workflows/dapr-deploy.yml
+++ b/.github/workflows/dapr-deploy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
-      DAPR_RUNTIME_VER: 1.10.7-rc.2
+      DAPR_RUNTIME_VER: 1.11.0-rc.5
       DAPR_NAMESPACE: dapr-system
       TEST_CLUSTER_NAME: dapr-release-longhaul
       TEST_RESOURCE_GROUP: dapr-test

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Dapr.Client" Version="1.10.0" />
-    <PackageVersion Include="Dapr.AspNetCore" Version="1.10.0" />
-    <PackageVersion Include="Dapr.Actors.AspNetCore" Version="1.10.0" />
+    <PackageVersion Include="Dapr.Client" Version="1.11.0-rc01" />
+    <PackageVersion Include="Dapr.AspNetCore" Version="1.11.0-rc01" />
+    <PackageVersion Include="Dapr.Actors.AspNetCore" Version="1.11.0-rc01" />
     <PackageVersion Include="prometheus-net" Version="3.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Description

Bump dapr and dotnet sdk to 1.11 rcs

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: 1.11 Endgame

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
