### PR TITLE
Moves the nightly longhaul workflow to weekly.

### DIFF
--- a/.github/workflows/dapr-longhaul-weekly.yml
+++ b/.github/workflows/dapr-longhaul-weekly.yml
@@ -11,11 +11,11 @@
 # limitations under the License.
 #
 
-name: dapr-longhaul-nightly
+name: dapr-longhaul-weekly
 
 on:
   schedule:
-   - cron: '0 7 * * *'
+   - cron: '0 7 * * 5'  # Fridays, 7am UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Description


As discussed during release planning, we are moving the nightly longhaul workflow to weekly. This PR does so by renaming the workflow file and modifying its cron rule to run weekly on Fridays, 7am UTC.

This change aims to give us more time to let longhaul bake and expose any potential resource leaks and bugs that are only exposed after a long period execution time. Previously we were only performing something similar with release candidates, too late in the release process.

Fridays were chosen to give 3-4 days of baking before release meetings while still giving the change to catch the majority of the merges, which for `components-contrib` take place between Mondays and Thursdays (see command bellow). It also leaves Friday and Monday as days to address any deployment problems with the longhaul cluster before release meetings.

Merge frequency by weekday checked with

```
git log master --first-parent --merges \
    --pretty=format:"%h %C(white)%<(15)%aD%Creset %C(red bold)%<(15)%D%Creset %s" | \
    awk '{print $2}' | sort | uniq -c | sort -rn
```

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
