### PR TITLE
Update longhaul tests to use dapr version v1.11.2-rc.2

### DIFF
--- a/.github/workflows/dapr-deploy.yml
+++ b/.github/workflows/dapr-deploy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
-      DAPR_RUNTIME_VER: 1.11.0-rc.9
+      DAPR_RUNTIME_VER: 1.11.2-rc.2
       DAPR_NAMESPACE: dapr-system
       TEST_CLUSTER_NAME: dapr-release-longhaul
       TEST_RESOURCE_GROUP: dapr-test


### PR DESCRIPTION
@artursouza 

Let me know if I have done this correctly.