### PR TITLE
Increase workflow create timer

### DIFF
--- a/workflow-gen/Program.cs
+++ b/workflow-gen/Program.cs
@@ -48,7 +48,7 @@ namespace WorkflowGen
                 });
             });
 
-            var wTimer = StartExecutingWorkflows(15);
+            var wTimer = StartExecutingWorkflows(30);
             using var host = builder.Build();
             host.Run();
             wTimer.Dispose();


### PR DESCRIPTION
# Description

_Please explain the changes you've made_

With the artificial delays in the workflow app 15 seconds might be too short of a timer. Increasing it to 30 seconds should be enough time.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
