### PR TITLE
Update release longhaul to Dapr & dotNet latest 1.12.0 release candidate

### DIFF
--- a/.github/workflows/dapr-deploy.yml
+++ b/.github/workflows/dapr-deploy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
-      DAPR_RUNTIME_VER: 1.11.2-rc.2
+      DAPR_RUNTIME_VER: 1.12.0-rc.1
       DAPR_NAMESPACE: dapr-system
       TEST_CLUSTER_NAME: dapr-release-longhaul
       TEST_RESOURCE_GROUP: dapr-test

--- a/.github/workflows/dapr-deploy.yml
+++ b/.github/workflows/dapr-deploy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
-      DAPR_RUNTIME_VER: 1.12.0-rc.1
+      DAPR_RUNTIME_VER: 1.12.0-rc.2
       DAPR_NAMESPACE: dapr-system
       TEST_CLUSTER_NAME: dapr-release-longhaul
       TEST_RESOURCE_GROUP: dapr-test

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,9 +1,9 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Dapr.Client" Version="1.11.0" />
-    <PackageVersion Include="Dapr.AspNetCore" Version="1.11.0" />
-    <PackageVersion Include="Dapr.Actors.AspNetCore" Version="1.11.0" />
+    <PackageVersion Include="Dapr.Client" Version="1.12.0-rc01" />
+    <PackageVersion Include="Dapr.AspNetCore" Version="1.12.0-rc01" />
+    <PackageVersion Include="Dapr.Actors.AspNetCore" Version="1.12.0-rc01" />
+    <PackageVersion Include="Dapr.Workflow" Version="1.12.0-rc01" />
     <PackageVersion Include="prometheus-net" Version="3.5.0" />
-    <PackageVersion Include="Dapr.Workflow" Version="1.11.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Description

* Update Dapr to last release candidate (`1.12.0-rc.2`).
* Update dotNet SDK to last release candidate (`1.12.0-rc01`)


## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
