### PR TITLE
Launch longhaul using dapr multiapp launcher.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,44 @@
 
 This repo includes test apps and infrastructure tools.
 
-* [Feed Generator](./feed-generator) : Test app for long haul test, contains feed-generator logic.
-* [Message Analyzer](./message-analyzer) : Test app for long haul test, contains message-analyzer logic.
-* [HashTag Counter](./hashtag-counter) : Test app for long haul test, contains hashtag-counter.
-* [HashTag Actor](./hashtag-actor) : Test app for long haul test, hashtag-actor logic.
-* [Pubsub Workflow](./pubsub-workflow) : Test app for long haul test, azure service bus pubsub logic.
+Test apps for long haul tests:
+* [Feed Generator](./feed-generator) : contains feed-generator logic. Exercises the pubsub component (publishing).
+* [Message Analyzer](./message-analyzer) : contains message-analyzer logic. Exercises pubsub component (subscribing) and output binding.
+* [HashTag Counter](./hashtag-counter) : contains hashtag-counter. Exercises input binding and actor component.
+* [HashTag Actor](./hashtag-actor) : hashtag-actor logic. Exercises actor component. 
+* [Pubsub Workflow](./pubsub-workflow) : azure service bus pubsub logic. Exercises pubsub component (publishing and subscribing).
+
+Test analytics :
 * [Test Crawler](./test-crawler) : A Python script scrapes the Dapr E2E tests results.
 
 # Solution overview and app dependency
 
 ```mermaid
 sequenceDiagram
-FeedGenerator -->> MessageAnalyzer : publish a SocialMediaMessage async using pubsub
-MessageAnalyzer -->> HashTagCounter: invoke a binding publish message to a StorageQueue
-HashTagCounter ->> HashTagActor: increase counter in message's hashtag's actor
-
-Snapshot -->> HashTagActor: get counts from actor
+FeedGenerator --) MessageAnalyzer : publish a SocialMediaMessage <br> async using pubsub <br> topic "receivemediapost"
+MessageAnalyzer --) HashTagCounter: invoke output binding "messagebinding" <br> to publish a message to a queue <br> shared with HashTagCounter
+HashTagCounter ->> HashTagActor: receives messages from shared queue <br> using input binding "messagebinding" <br> increase counter by invoking a <br> per (hastag,sentiment) actor
+Snapshot ->> HashTagActor: get counts from HashTagActor
+PubSubWorkflow --) PubSubWorkflow: publish messages at different rates <br> to different topics it also subscribes to.
 ```
 
 TODO what about Pubsub Workflow ? who is publishing to it? And validation workflow?
 
 # Deploying this application
 
-## Locally with docker-compose or `dapr run -f`
+## Locally with Dapr Multi-App run
 
-TBD -- does it even work?
+This is not properly a deployment, but it is a way to run all the longhaul applications locally using [Dapr Multi-App run](https://docs.dapr.io/developing-applications/local-development/multi-app-dapr-run/).
+
+
+```bash	
+# Start base components such as redis and zipkin, which we depend on
+dapr init
+# Start RabbitMQ which is used for our input/output binding tests.
+docker run -d -p 5672:5672 --hostname dapr_rabbitmq --name dapr_rabbitmq rabbitmq:3-alpine
+# Run all the apps
+dapr run -f deploy/dapr-multi-app/dapr.yaml
+```
 
 ## On Azure Kubernetes Service (AKS)
 

--- a/common/Metrics/MetricsServer.cs
+++ b/common/Metrics/MetricsServer.cs
@@ -1,0 +1,32 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+using Prometheus;
+using System;
+
+namespace Dapr.Tests.Common {
+
+    public static class ObservabilityUtils {
+        public static bool StartMetricsServer()
+        {
+            // if the env. var. is unset or empty, we enable the metric server
+            bool enablePrometheusMetricServer = string.IsNullOrWhiteSpace(
+                Environment.GetEnvironmentVariable("DISABLE_PROMETHEUS_METRIC_SERVER"));
+
+            if (enablePrometheusMetricServer)
+            {
+                Console.WriteLine("Starting Prometheus metric server");
+                new MetricServer(port: 9988).Start();
+            }
+            else
+            {
+                Console.WriteLine("Disabling Prometheus metric server");
+            }
+
+            return enablePrometheusMetricServer;
+        }
+    }
+
+}

--- a/common/common.csproj
+++ b/common/common.csproj
@@ -2,12 +2,17 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\.dockerignore" Link="Models\.dockerignore">
       <DependentUpon>$(DockerDefaultDockerfile)</DependentUpon>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="prometheus-net" />
   </ItemGroup>
 
 </Project>

--- a/deploy/dapr-multi-app/components/longhaul-sb-glacial.yaml
+++ b/deploy/dapr-multi-app/components/longhaul-sb-glacial.yaml
@@ -1,0 +1,12 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: longhaul-sb-glacial
+spec:
+  type: pubsub.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""

--- a/deploy/dapr-multi-app/components/longhaul-sb-medium.yaml
+++ b/deploy/dapr-multi-app/components/longhaul-sb-medium.yaml
@@ -1,0 +1,12 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: longhaul-sb-medium
+spec:
+  type: pubsub.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""

--- a/deploy/dapr-multi-app/components/longhaul-sb-rapid.yaml
+++ b/deploy/dapr-multi-app/components/longhaul-sb-rapid.yaml
@@ -1,0 +1,12 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: longhaul-sb-rapid
+spec:
+  type: pubsub.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""

--- a/deploy/dapr-multi-app/components/longhaul-sb-slow.yaml
+++ b/deploy/dapr-multi-app/components/longhaul-sb-slow.yaml
@@ -1,0 +1,12 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: longhaul-sb-slow
+spec:
+  type: pubsub.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""

--- a/deploy/dapr-multi-app/components/messagebinding.yaml
+++ b/deploy/dapr-multi-app/components/messagebinding.yaml
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: messagebinding
+spec:
+  type: bindings.rabbitmq
+  version: v1
+  metadata:
+  - name: queueName
+    value: "messagebindingqueue"
+  - name: host
+    value: "amqp://guest:guest@localhost:5672"

--- a/deploy/dapr-multi-app/components/receivemediapost.yaml
+++ b/deploy/dapr-multi-app/components/receivemediapost.yaml
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: receivemediapost
+spec:
+  type: pubsub.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""

--- a/deploy/dapr-multi-app/components/statestore.yaml
+++ b/deploy/dapr-multi-app/components/statestore.yaml
@@ -1,0 +1,14 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""
+  - name: actorStateStore
+    value: "true"

--- a/deploy/dapr-multi-app/dapr.yaml
+++ b/deploy/dapr-multi-app/dapr.yaml
@@ -1,0 +1,33 @@
+version: 1
+# Hi! Unfamiliar with Dapr multi-app run capabilities? Check out the docs:
+# * https://docs.dapr.io/developing-applications/local-development/multi-app-dapr-run/multi-app-overview/
+common:
+  resourcesPath: ./components
+  appLogDestination: console
+  daprdLogDestination: console
+  env:
+    DISABLE_PROMETHEUS_METRIC_SERVER: "true"
+apps:
+  - appID: feed-generator
+    appDirPath: ../../feed-generator
+    appPort: 3000
+    command: ["dotnet","run"]  # Ideally this app should accept opts. 
+  - appID: message-analyzer
+    appDirPath: ../../message-analyzer
+    daprHTTPPort: 3512
+    appPort: 3002
+    command: ["dotnet","run", "--DaprHTTPAppPort=3002"]
+  - appID: hashtag-actor
+    appDirPath: ../../hashtag-actor
+    daprHTTPPort: 3513
+    appPort: 3003
+    command: ["dotnet","run", "--DaprHTTPAppPort=3003"]
+  - appID: hashtag-counter
+    appDirPath: ../../hashtag-counter
+    daprHTTPPort: 3514
+    appPort: 3004
+    command: ["dotnet","run", "--DaprHTTPAppPort=3004"]
+  - appID: pubsub-workflow
+    appDirPath: ../../pubsub-workflow
+    appPort: 3005
+    command: ["dotnet","run", "--DaprHTTPAppPort=3005"]

--- a/deploy/dapr-multi-app/test.http
+++ b/deploy/dapr-multi-app/test.http
@@ -1,0 +1,32 @@
+
+
+
+POST http://localhost:3004/messagebinding HTTP/1.1
+content-type: application/json
+
+{
+    "correlationId":"0f8fad5b-d9cb-469f-a165-70867728950e",
+    "messageId":"ffffad5b-d9cb-469f-a165-7086772895ff",
+    "message": "test 1",
+    "sentiment": "positive",
+    "creationDate": "2023-09-11T17:16:40"
+}
+
+###
+
+PUT http://localhost:3513/v1.0/actors/HashTagActor/test2_positive/method/Increment HTTP/1.1
+content-type: application/json
+
+"test2_positive"
+
+###
+
+PUT http://localhost:3513/v1.0/actors/HashTagActor/test2_positive/method/GetCount HTTP/1.1
+content-type: application/json
+
+"test2_positive"
+
+
+###
+
+http://localhost:3514/v1.0/metadata

--- a/feed-generator/Program.cs
+++ b/feed-generator/Program.cs
@@ -6,6 +6,7 @@
 namespace FeedGenerator
 {
     using Dapr.Client;
+    using Dapr.Tests.Common;
     using Dapr.Tests.Common.Models;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Hosting;
@@ -41,8 +42,7 @@ namespace FeedGenerator
                 }
             }
 
-            var server = new MetricServer(port: 9988);
-            server.Start();
+            ObservabilityUtils.StartMetricsServer();
 
             IHost host = CreateHostBuilder(args).Build();
 

--- a/hashtag-actor/Program.cs
+++ b/hashtag-actor/Program.cs
@@ -5,6 +5,7 @@
 
 namespace Dapr.Tests.HashTagApp
 {
+    using Dapr.Tests.Common;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Hosting;
@@ -15,6 +16,8 @@ namespace Dapr.Tests.HashTagApp
     {
         public static void Main(string[] args)
         {
+            ObservabilityUtils.StartMetricsServer();
+            
             CreateHostBuilder(args).Build().Run();
         }
 

--- a/hashtag-counter/Program.cs
+++ b/hashtag-counter/Program.cs
@@ -5,22 +5,20 @@
 
 namespace Dapr.Tests.HashTagApp
 {
-    using System;
-    using System.IO;
+    using Dapr.Tests.Common;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
-    using Prometheus;
+    using System;
+    using System.IO;
 
     public class Program
     {
         public static void Main(string[] args)
         {
-            var server = new MetricServer(port: 9988);
-            server.Start();
+            ObservabilityUtils.StartMetricsServer();
 
-           
             CreateHostBuilder(args).Build().Run();
         }
 

--- a/message-analyzer/appsettings.json
+++ b/message-analyzer/appsettings.json
@@ -6,5 +6,6 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "DaprHTTPAppPort": "3000"
 }

--- a/pubsub-workflow/Program.cs
+++ b/pubsub-workflow/Program.cs
@@ -4,11 +4,11 @@
 // ------------------------------------------------------------
 
 using Dapr.Client;
+using Dapr.Tests.Common;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Prometheus;
 using System;
 using System.IO;
 using System.Threading;
@@ -28,8 +28,7 @@ namespace PubsubWorkflow
         {
             Console.WriteLine("Starting Pubsub Workflow");
 
-            var server = new MetricServer(port: 9988);
-            server.Start();
+            ObservabilityUtils.StartMetricsServer();
 
             var host = CreateHostBuilder(args).Build();
 

--- a/pubsub-workflow/pubsub-workflow.csproj
+++ b/pubsub-workflow/pubsub-workflow.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="prometheus-net" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\common\common.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/snapshot/Program.cs
+++ b/snapshot/Program.cs
@@ -8,6 +8,7 @@ namespace Dapr.Tests.Snapshot
     using Dapr.Actors;
     using Dapr.Actors.Client;
     using Dapr.Client;
+    using Dapr.Tests.Common;
     using Dapr.Tests.Common.Models;
     using Dapr.Tests.HashTagApp.Actors;
     using Microsoft.AspNetCore.Hosting;
@@ -40,8 +41,7 @@ namespace Dapr.Tests.Snapshot
 
             Console.WriteLine("Configured delayInMilliseconds={0}", delayInMilliseconds);
 
-            var server = new MetricServer(port: 9988);
-            server.Start();
+            ObservabilityUtils.StartMetricsServer();
 
             var host = CreateHostBuilder(args).Build();
 

--- a/workflow-gen/Program.cs
+++ b/workflow-gen/Program.cs
@@ -5,12 +5,12 @@ using System.Globalization;
 // ------------------------------------------------------------
 
 using Dapr.Client;
+using Dapr.Tests.Common;
 using Dapr.Workflow;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Prometheus;
 using System;
 using System.IO;
 using System.Threading;
@@ -33,8 +33,7 @@ namespace WorkflowGen
         /// <param name="args">Arguments.</param>
         public static void Main(string[] args)
         {
-            var server = new MetricServer(port: 9988);
-            server.Start();
+            ObservabilityUtils.StartMetricsServer();
 
             var builder = Host.CreateDefaultBuilder(args).ConfigureServices(services =>
             {


### PR DESCRIPTION
# Description

* Provides a dapr.yaml along with component configuration to allow launch most of the longhaull applications locally using MultiApp launch.
* Updates README to better describe how  most longhaul applications interact.
* Update README to describe how to launch longhauls using dapr
  multiapp launcher.
* Unifies and simplifies code to launch prometheus metric launcher in C# code.
  * Metric server can be disabled using `DISABLE_PROMETHEUS_METRIC_SERVER`
    environment variable.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
