### PR TITLE
Change default message-analyzer app port back to 80

### DIFF
--- a/message-analyzer/appsettings.json
+++ b/message-analyzer/appsettings.json
@@ -7,5 +7,5 @@
     }
   },
   "AllowedHosts": "*",
-  "DaprHTTPAppPort": "3000"
+  "DaprHTTPAppPort": "80"
 }


### PR DESCRIPTION
# Description

In #189 we updated message-analyzer app with the ability to bind on a user-configurable port, unblocking that PR.

Unfortunately that changed the default port used by that application (from `80` to `3000`), which impacts longhauls in general. This PR fixes this.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
