### PR TITLE
Switch to JSON-based log entries.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,8 @@
     <PackageVersion Include="Dapr.AspNetCore" Version="1.12.0-rc01" />
     <PackageVersion Include="Dapr.Actors.AspNetCore" Version="1.12.0-rc01" />
     <PackageVersion Include="Dapr.Workflow" Version="1.12.0-rc01" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageVersion Include="prometheus-net" Version="3.5.0" />
   </ItemGroup>
 </Project>

--- a/common/HostBuilderExtensions.cs
+++ b/common/HostBuilderExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Dapr.Tests.Common;
+
+public static class HostBuilderExtensions
+{
+    public static IHostBuilder ConfigureTestInfraLogging(this IHostBuilder builder)
+    {
+        return builder.ConfigureLogging(
+            (hostingContext, config) =>
+            {
+                config.ClearProviders();
+                config.AddJsonConsole();
+            });
+    }
+}

--- a/common/common.csproj
+++ b/common/common.csproj
@@ -12,6 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="prometheus-net" />
   </ItemGroup>
 

--- a/feed-generator/Program.cs
+++ b/feed-generator/Program.cs
@@ -8,8 +8,8 @@ namespace FeedGenerator
     using Dapr.Client;
     using Dapr.Tests.Common;
     using Dapr.Tests.Common.Models;
-    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
     using Prometheus;

--- a/feed-generator/Program.cs
+++ b/feed-generator/Program.cs
@@ -36,12 +36,7 @@ namespace FeedGenerator
             ObservabilityUtils.StartMetricsServer();
 
             IHost host = CreateHostBuilder(args)
-                .ConfigureLogging((hostingContext, config) =>
-                {
-                    config.ClearProviders();
-                    config.AddJsonConsole();
-
-                })
+                .ConfigureTestInfraLogging()
                 .Build();
 
             var logger = host.Services.GetRequiredService<ILogger<Program>>();

--- a/feed-generator/Program.cs
+++ b/feed-generator/Program.cs
@@ -35,7 +35,14 @@ namespace FeedGenerator
         {
             ObservabilityUtils.StartMetricsServer();
 
-            IHost host = CreateHostBuilder(args).Build();
+            IHost host = CreateHostBuilder(args)
+                .ConfigureLogging((hostingContext, config) =>
+                {
+                    config.ClearProviders();
+                    config.AddJsonConsole();
+
+                })
+                .Build();
 
             var logger = host.Services.GetRequiredService<ILogger<Program>>();
 

--- a/feed-generator/Program.cs
+++ b/feed-generator/Program.cs
@@ -8,8 +8,10 @@ namespace FeedGenerator
     using Dapr.Client;
     using Dapr.Tests.Common;
     using Dapr.Tests.Common.Models;
+    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Logging;
     using Prometheus;
     using System;
     using System.Threading.Tasks;
@@ -31,22 +33,24 @@ namespace FeedGenerator
         /// <param name="args">Arguments.</param>
         public static void Main(string[] args)
         {
+            ObservabilityUtils.StartMetricsServer();
+
+            IHost host = CreateHostBuilder(args).Build();
+
+            var logger = host.Services.GetRequiredService<ILogger<Program>>();
+
             int delayInMilliseconds = 10000;
             if (args.Length != 0 && args[0] != "%LAUNCHER_ARGS%")
             {
                 if (int.TryParse(args[0], out delayInMilliseconds) == false)
                 {
                     string msg = "Could not parse delay";
-                    Console.WriteLine(msg);
+                    logger.LogError(msg);
                     throw new InvalidOperationException(msg);
                 }
             }
 
-            ObservabilityUtils.StartMetricsServer();
-
-            IHost host = CreateHostBuilder(args).Build();
-
-            Task.Run(() => StartMessageGeneratorAsync(delayInMilliseconds));
+            Task.Run(() => StartMessageGeneratorAsync(delayInMilliseconds, logger));
 
             host.Run();
         }
@@ -63,7 +67,7 @@ namespace FeedGenerator
                     webBuilder.UseStartup<Startup>();
                 });
 
-        static internal async void StartMessageGeneratorAsync(int delayInMilliseconds)
+        static internal async void StartMessageGeneratorAsync(int delayInMilliseconds, ILogger<Program> logger)
         {
             // the name of the component and the topic happen to be the same here...
             const string PubsubComponentName = "receivemediapost";
@@ -80,7 +84,7 @@ namespace FeedGenerator
 
                 try
                 {
-                    Console.WriteLine("Publishing");
+                    logger.LogInformation("Publishing");
                     using (PublishCallTime.NewTimer())
                     {
                         await client.PublishEventAsync<SocialMediaMessage>(PubsubComponentName, PubsubTopicName, message);
@@ -88,7 +92,7 @@ namespace FeedGenerator
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("Caught {0}", e.ToString());
+                    logger.LogError(e, "Caught {Exception}", e);
                     PublishFailureCount.Inc();
                 }
 

--- a/hashtag-actor/Actors/HashTagActor.cs
+++ b/hashtag-actor/Actors/HashTagActor.cs
@@ -20,20 +20,10 @@ namespace Dapr.Tests.HashTagApp.Actors
         /// Initializes a new instance of the <see cref="HashTagActor"/> class.
         /// </summary>
         /// <param name="host">Actor Service hosting the actor.</param>
-        public HashTagActor(ActorHost host)
+        public HashTagActor(ActorHost host, ILogger<HashTagActor> logger)
             : base(host)
         {
-            // TODO: ActorHost may need to have IHostBuilder reference to allow user to interact web host.
-            // For example, getting logger factory given by WebHost
-            var loggerFactory = LoggerFactory.Create(builder =>
-            {
-                builder
-                    .AddFilter("Microsoft", LogLevel.Warning)
-                    .AddFilter("System", LogLevel.Warning)
-                    .AddConsole();
-            });
-
-            this.logger = loggerFactory.CreateLogger<HashTagActor>();
+            this.logger = logger;
         }
 
         /// <inheritdoc/>
@@ -47,13 +37,13 @@ namespace Dapr.Tests.HashTagApp.Actors
             }
             catch (KeyNotFoundException)
             {
-                this.logger.LogDebug($"{hashtagAndSentiment} does not exist. {hashtagAndSentiment} will be initialized to 0.");
+                this.logger.LogDebug("{HashtagAndSentiment} does not exist. {HashtagAndSentiment} will be initialized to 0.", hashtagAndSentiment);
             }
 
-            this.logger.LogDebug($"{hashtagAndSentiment} = {count}");
+            this.logger.LogDebug("{HashtagAndSentiment} = {Count}", hashtagAndSentiment, count);
             count++;
             await this.StateManager.SetStateAsync<int>(hashtagAndSentiment, count);
-            this.logger.LogInformation($"Incremented {hashtagAndSentiment}.");
+            this.logger.LogInformation("Incremented {HashtagAndSentiment}.", hashtagAndSentiment);
         }
 
         public async Task<int> GetCount(string hashtagAndSentiment)
@@ -62,11 +52,11 @@ namespace Dapr.Tests.HashTagApp.Actors
             try
             {
                 count = await this.StateManager.GetStateAsync<int>(hashtagAndSentiment);
-                this.logger.LogInformation($"GetCount for {hashtagAndSentiment} found and it is {count}.");
+                this.logger.LogInformation("GetCount for {HashtagAndSentiment} found and it is {Count}.", hashtagAndSentiment, count);
             }
             catch (KeyNotFoundException)
             {
-                this.logger.LogInformation($"{hashtagAndSentiment} does not exist.");
+                this.logger.LogInformation("{HashtagAndSentiment} does not exist.", hashtagAndSentiment);
             }
 
             return count;

--- a/hashtag-actor/Program.cs
+++ b/hashtag-actor/Program.cs
@@ -27,7 +27,7 @@ namespace Dapr.Tests.HashTagApp
                 .ConfigureLogging((hostingContext, config) =>
                 {
                     config.ClearProviders();
-                    config.AddConsole();
+                    config.AddJsonConsole();
 
                 })
                 .ConfigureWebHostDefaults(webBuilder =>

--- a/hashtag-actor/Program.cs
+++ b/hashtag-actor/Program.cs
@@ -24,12 +24,7 @@ namespace Dapr.Tests.HashTagApp
         public static IHostBuilder CreateHostBuilder(string[] args)
         {
             var hostBuilder = Host.CreateDefaultBuilder(args)
-                .ConfigureLogging((hostingContext, config) =>
-                {
-                    config.ClearProviders();
-                    config.AddJsonConsole();
-
-                })
+                .ConfigureTestInfraLogging()
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     var appSettings = new ConfigurationBuilder()

--- a/hashtag-actor/Startup.cs
+++ b/hashtag-actor/Startup.cs
@@ -33,7 +33,6 @@ namespace Dapr.Tests.HashTagApp
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            Console.WriteLine("Configure");
             if (env.EnvironmentName.Contains(".dev"))
             {
                 app.UseDeveloperExceptionPage();

--- a/hashtag-counter/Program.cs
+++ b/hashtag-counter/Program.cs
@@ -27,7 +27,7 @@ namespace Dapr.Tests.HashTagApp
                 .ConfigureLogging((hostingContext, config) =>
                 {
                     config.ClearProviders();
-                    config.AddConsole();
+                    config.AddJsonConsole();
 
                 })
                 .ConfigureWebHostDefaults(webBuilder =>

--- a/hashtag-counter/Program.cs
+++ b/hashtag-counter/Program.cs
@@ -24,12 +24,7 @@ namespace Dapr.Tests.HashTagApp
 
         public static IHostBuilder CreateHostBuilder(string[] args) {
             var hostBuilder = Host.CreateDefaultBuilder(args)
-                .ConfigureLogging((hostingContext, config) =>
-                {
-                    config.ClearProviders();
-                    config.AddJsonConsole();
-
-                })
+                .ConfigureTestInfraLogging()
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     var appSettings = new ConfigurationBuilder()

--- a/hashtag-counter/Startup.cs
+++ b/hashtag-counter/Startup.cs
@@ -27,7 +27,6 @@ namespace Dapr.Tests.HashTagApp
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            Console.WriteLine("ConfigureServices()");
             services.AddControllers();
 
         }
@@ -35,7 +34,6 @@ namespace Dapr.Tests.HashTagApp
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            Console.WriteLine("Configure");
             if (env.EnvironmentName.Contains(".dev"))
             {
                 app.UseDeveloperExceptionPage();

--- a/message-analyzer/Program.cs
+++ b/message-analyzer/Program.cs
@@ -41,12 +41,7 @@ namespace MessageAnalyzer
         /// <returns>Returns IHostbuilder.</returns>
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-                .ConfigureLogging((hostingContext, config) =>
-                {
-                    config.ClearProviders();
-                    config.AddJsonConsole();
-
-                })
+                .ConfigureTestInfraLogging()
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     var appSettings = new ConfigurationBuilder()

--- a/message-analyzer/Program.cs
+++ b/message-analyzer/Program.cs
@@ -29,8 +29,6 @@ namespace MessageAnalyzer
         /// <param name="args">Arguments.</param>
         public static void Main(string[] args)
         {
-            Console.WriteLine("Enter main");
-
             ObservabilityUtils.StartMetricsServer();
 
             CreateHostBuilder(args).Build().Run();

--- a/message-analyzer/Program.cs
+++ b/message-analyzer/Program.cs
@@ -44,7 +44,7 @@ namespace MessageAnalyzer
                 .ConfigureLogging((hostingContext, config) =>
                 {
                     config.ClearProviders();
-                    config.AddConsole();
+                    config.AddJsonConsole();
 
                 })
                 .ConfigureWebHostDefaults(webBuilder =>

--- a/pubsub-workflow/Controllers/PubsubController.cs
+++ b/pubsub-workflow/Controllers/PubsubController.cs
@@ -6,6 +6,7 @@
 using Dapr;
 using Dapr.Client;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 
@@ -19,12 +20,19 @@ namespace PubsubWorkflow
         internal static DateTime lastSlowCall = DateTime.Now;
         internal static DateTime lastGlacialCall = DateTime.Now;
 
+        private readonly ILogger<PubsubController> logger;
+
+        public PubsubController(ILogger<PubsubController> logger)
+        {
+            this.logger = logger;
+        }
+
         [Topic("longhaul-sb-rapid", "rapidtopic")]
         [HttpPost("rapidMessage")]
         public IActionResult RapidMessageHandler() {
             var lastHit = lastRapidCall;
             lastRapidCall = DateTime.Now;
-            Console.WriteLine($"Rapid subscription hit at {lastRapidCall}, previous hit at {lastHit}");
+            this.logger.LogInformation("Rapid subscription hit at {LastRapidCall}, previous hit at {LastHit}", lastRapidCall, lastHit);
             return Ok();
         }
 
@@ -33,7 +41,7 @@ namespace PubsubWorkflow
         public IActionResult MediumMessageHandler() {
             var lastHit = lastMediumCall;
             lastMediumCall = DateTime.Now;
-            Console.WriteLine($"Medium subscription hit at {lastMediumCall}, previous hit at {lastHit}");
+            this.logger.LogInformation("Medium subscription hit at {LastMediumCall}, previous hit at {LastHit}", lastMediumCall, lastHit);
             return Ok();
         }
 
@@ -42,7 +50,7 @@ namespace PubsubWorkflow
         public IActionResult SlowMessageHandler() {
             var lastHit = lastSlowCall;
             lastSlowCall = DateTime.Now;
-            Console.WriteLine($"Slow subscription hit at {lastSlowCall}, previous hit at {lastHit}");
+            this.logger.LogInformation("Slow subscription hit at {LastSlowCall}, previous hit at {LastHit}", lastSlowCall, lastHit);
             return Ok();
         }
         
@@ -51,7 +59,7 @@ namespace PubsubWorkflow
         public IActionResult GlacialMessageHandler() {
             var lastHit = lastGlacialCall;
             lastGlacialCall = DateTime.Now;
-            Console.WriteLine($"Glacial subscription hit at {lastGlacialCall}, previous hit at {lastHit}");
+            this.logger.LogInformation("Glacial subscription hit at {LastGlacialCall}, previous hit at {LastHit}", lastGlacialCall, lastHit);
             return Ok();
         }
     }

--- a/pubsub-workflow/Program.cs
+++ b/pubsub-workflow/Program.cs
@@ -52,23 +52,18 @@ namespace PubsubWorkflow
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-                .ConfigureLogging((hostingContext, config) =>
-                    {
-                        config.ClearProviders();
-                        config.AddJsonConsole();
+                .ConfigureTestInfraLogging()
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    var appSettings = new ConfigurationBuilder()
+                        .SetBasePath(Directory.GetCurrentDirectory())
+                        .AddJsonFile($"appsettings.json", optional: true, reloadOnChange: true)                        
+                        .AddCommandLine(args)
+                        .Build();
 
-                    })
-                    .ConfigureWebHostDefaults(webBuilder =>
-                    {
-                        var appSettings = new ConfigurationBuilder()
-                            .SetBasePath(Directory.GetCurrentDirectory())
-                            .AddJsonFile($"appsettings.json", optional: true, reloadOnChange: true)                        
-                            .AddCommandLine(args)
-                            .Build();
-
-                        webBuilder.UseStartup<Startup>()
-                            .UseUrls(urls: $"http://*:{appSettings["DaprHTTPAppPort"]}");
-                    });
+                    webBuilder.UseStartup<Startup>()
+                        .UseUrls(urls: $"http://*:{appSettings["DaprHTTPAppPort"]}");
+                });
 
         static internal Timer StartPublishingMessages(int periodInSeconds, string pubsubName, string topic)
         {

--- a/pubsub-workflow/Program.cs
+++ b/pubsub-workflow/Program.cs
@@ -55,7 +55,7 @@ namespace PubsubWorkflow
                 .ConfigureLogging((hostingContext, config) =>
                     {
                         config.ClearProviders();
-                        config.AddConsole();
+                        config.AddJsonConsole();
 
                     })
                     .ConfigureWebHostDefaults(webBuilder =>

--- a/pubsub-workflow/Program.cs
+++ b/pubsub-workflow/Program.cs
@@ -7,6 +7,7 @@ using Dapr.Client;
 using Dapr.Tests.Common;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
@@ -26,11 +27,13 @@ namespace PubsubWorkflow
 
         static void Main(string[] args)
         {
-            Console.WriteLine("Starting Pubsub Workflow");
-
             ObservabilityUtils.StartMetricsServer();
 
             var host = CreateHostBuilder(args).Build();
+
+            var logger = host.Services.GetRequiredService<ILogger<PubsubWorkflow>>();
+
+            logger.LogInformation("Starting Pubsub Workflow");
 
             var rapidTimer = StartPublishingMessages(10, rapidPubsubName, "rapidtopic");
             var mediumTimer = StartPublishingMessages(300, mediumPubsubName, "mediumtopic");
@@ -39,7 +42,7 @@ namespace PubsubWorkflow
             
             host.Run();
 
-            Console.WriteLine("Exiting Pubsub Workflow");
+            logger.LogInformation("Exiting Pubsub Workflow");
 
             rapidTimer.Dispose();
             mediumTimer.Dispose();

--- a/snapshot/Controllers/HashTagController.cs
+++ b/snapshot/Controllers/HashTagController.cs
@@ -18,17 +18,18 @@ namespace Dapr.Tests.Snapshot.Controllers
     public class HashTagController : ControllerBase
     {
         private readonly IConfiguration configuration;
+        private readonly ILogger<HashTagController> logger;
 
-        public HashTagController(IConfiguration config)
+        public HashTagController(IConfiguration config), ILogger<HashTagController> logger)
         {
-            Console.WriteLine("ctor.");
             this.configuration = config;
+            this.logger = logger;
         }
 
         [HttpGet("hashtagdata")]
         public async Task<Dictionary<string, int>> GetHashTagData([FromServices]DaprClient daprClient)
         {
-            Console.WriteLine("enter GetHashTagData");
+            this.logger.LogDebug("enter GetHashTagData");
             var stats = await daprClient.GetStateAsync<Dictionary<string, int>>("statestore", "statskey");
 
             return stats;

--- a/snapshot/Controllers/HashTagController.cs
+++ b/snapshot/Controllers/HashTagController.cs
@@ -8,6 +8,7 @@ namespace Dapr.Tests.Snapshot.Controllers
     using Dapr.Client;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
     using System;
     using System.Collections.Generic;
     using System.Net.Mime;
@@ -20,7 +21,7 @@ namespace Dapr.Tests.Snapshot.Controllers
         private readonly IConfiguration configuration;
         private readonly ILogger<HashTagController> logger;
 
-        public HashTagController(IConfiguration config), ILogger<HashTagController> logger)
+        public HashTagController(IConfiguration config, ILogger<HashTagController> logger)
         {
             this.configuration = config;
             this.logger = logger;

--- a/snapshot/Program.cs
+++ b/snapshot/Program.cs
@@ -59,7 +59,7 @@ namespace Dapr.Tests.Snapshot
                 .ConfigureLogging((hostingContext, config) =>
                 {
                     config.ClearProviders();
-                    config.AddConsole();
+                    config.AddJsonConsole();
 
                 })
                 .ConfigureWebHostDefaults(webBuilder =>

--- a/snapshot/Program.cs
+++ b/snapshot/Program.cs
@@ -46,9 +46,9 @@ namespace Dapr.Tests.Snapshot
                 delayInMilliseconds = int.Parse(delay);
             }
 
-            logger.LogDebug("Configured delayInMilliseconds={DelayInMilliseconds}", delayInMilliseconds, logger);
+            logger.LogDebug("Configured delayInMilliseconds={DelayInMilliseconds}", delayInMilliseconds);
 
-            Task.Run(() => StartQueryLoopAsync(delayInMilliseconds));
+            Task.Run(() => StartQueryLoopAsync(delayInMilliseconds, logger));
 
             host.Run();
         }
@@ -56,12 +56,7 @@ namespace Dapr.Tests.Snapshot
         public static IHostBuilder CreateHostBuilder(string[] args)
         {
             var hostBuilder = Host.CreateDefaultBuilder(args)
-                .ConfigureLogging((hostingContext, config) =>
-                {
-                    config.ClearProviders();
-                    config.AddJsonConsole();
-
-                })
+                .ConfigureTestInfraLogging()
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     var appSettings = new ConfigurationBuilder()

--- a/snapshot/Startup.cs
+++ b/snapshot/Startup.cs
@@ -23,7 +23,6 @@ namespace Dapr.Tests.Snapshot
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            Console.WriteLine("ConfigureServices()");
             services.AddDaprClient();
             services.AddControllers();
         }
@@ -31,7 +30,6 @@ namespace Dapr.Tests.Snapshot
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            Console.WriteLine("Configure");
             if (env.EnvironmentName.Contains(".dev"))
             {
                 app.UseDeveloperExceptionPage();

--- a/validation-worker/Program.cs
+++ b/validation-worker/Program.cs
@@ -43,7 +43,14 @@ namespace ValidationWorker
             var server = new MetricServer(port: 9988);
             server.Start();
 
-            IHost host = CreateHostBuilder(args).Build();
+            IHost host = CreateHostBuilder(args)
+                .ConfigureLogging((hostingContext, config) =>
+                {
+                    config.ClearProviders();
+                    config.AddJsonConsole();
+
+                })
+                .Build();
 
             var logger = host.Services.GetRequiredService<ILogger<Program>>();
 

--- a/validation-worker/Program.cs
+++ b/validation-worker/Program.cs
@@ -6,6 +6,7 @@
 namespace ValidationWorker
 {
     using Dapr.Client;
+    using Dapr.Tests.Common;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
@@ -44,12 +45,7 @@ namespace ValidationWorker
             server.Start();
 
             IHost host = CreateHostBuilder(args)
-                .ConfigureLogging((hostingContext, config) =>
-                {
-                    config.ClearProviders();
-                    config.AddJsonConsole();
-
-                })
+                .ConfigureTestInfraLogging()
                 .Build();
 
             var logger = host.Services.GetRequiredService<ILogger<Program>>();

--- a/validation-worker/validation-worker.csproj
+++ b/validation-worker/validation-worker.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\common\common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Dapr.AspNetCore" />
     <PackageReference Include="prometheus-net" />
   </ItemGroup>

--- a/workflow-gen/Activities/UpdateInventoryActivity.cs
+++ b/workflow-gen/Activities/UpdateInventoryActivity.cs
@@ -23,7 +23,7 @@ namespace WorkflowGen.Activities
         public override async Task<Object> RunAsync(WorkflowActivityContext context, PaymentRequest req)
         {
             this.logger.LogInformation(
-                "Checking Inventory for: Order# {requestId} for {amount} {item}",
+                "Checking Inventory for: Order# {RequestId} for {Amount} {Item}",
                 req.RequestId,
                 req.Amount,
                 req.ItemBeingPruchased);
@@ -36,13 +36,13 @@ namespace WorkflowGen.Activities
             if (newQuantity < 0)
             {
                 this.logger.LogInformation(
-                    "Payment for request ID '{requestId}' could not be processed. Insufficient inventory.",
+                    "Payment for request ID '{RequestId}' could not be processed. Insufficient inventory.",
                     req.RequestId);
                 throw new InvalidOperationException();
             }
 
             await client.SaveStateAsync<OrderPayload>(storeName, req.ItemBeingPruchased, new OrderPayload(Name: req.ItemBeingPruchased, TotalCost: req.Currency, Quantity: newQuantity));
-            this.logger.LogInformation($"There are now: {newQuantity} {original.Name} left in stock");
+            this.logger.LogInformation("There are now: {NewQuantity} {OriginalName} left in stock", newQuantity, original.Name);
 
             return null;
         }

--- a/workflow-gen/Program.cs
+++ b/workflow-gen/Program.cs
@@ -9,6 +9,7 @@ using Dapr.Tests.Common;
 using Dapr.Workflow;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
@@ -35,34 +36,42 @@ namespace WorkflowGen
         {
             ObservabilityUtils.StartMetricsServer();
 
-            var builder = Host.CreateDefaultBuilder(args).ConfigureServices(services =>
-            {
-                services.AddDaprWorkflow(options =>
+            var builder = Host.CreateDefaultBuilder(args)
+                .ConfigureLogging((hostingContext, config) =>
                 {
-                    options.RegisterWorkflow<OrderProcessingWorkflow>();
-                    options.RegisterActivity<NotifyActivity>();
-                    options.RegisterActivity<ReserveInventoryActivity>();
-                    options.RegisterActivity<ProcessPaymentActivity>();
-                    options.RegisterActivity<UpdateInventoryActivity>();
+                    config.ClearProviders();
+                    config.AddJsonConsole();
+                })
+                .ConfigureServices(services =>
+                {
+                    services.AddDaprWorkflow(options =>
+                    {
+                        options.RegisterWorkflow<OrderProcessingWorkflow>();
+                        options.RegisterActivity<NotifyActivity>();
+                        options.RegisterActivity<ReserveInventoryActivity>();
+                        options.RegisterActivity<ProcessPaymentActivity>();
+                        options.RegisterActivity<UpdateInventoryActivity>();
+                    });
                 });
-            });
 
-            var wTimer = StartExecutingWorkflows(30);
             using var host = builder.Build();
+
+            var logger = host.Services.GetRequiredService<ILogger<WorkflowRunner>>();
+
+            var wTimer = StartExecutingWorkflows(30, logger);
             host.Run();
             wTimer.Dispose();
         }
 
-        static internal Timer StartExecutingWorkflows(int periodInSeconds)
+        static internal Timer StartExecutingWorkflows(int periodInSeconds, ILogger<WorkflowRunner> logger)
         {
             DaprClientBuilder daprClientBuilder = new DaprClientBuilder();
             var client = new DaprClientBuilder().Build();
             var counter = 0;
-            var workflowRunner = new WorkflowRunner(client, counter);
+            var workflowRunner = new WorkflowRunner(client, counter, logger);
 
             return new Timer(workflowRunner.Execute, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(periodInSeconds));
         }
-
     }
 }
 

--- a/workflow-gen/Program.cs
+++ b/workflow-gen/Program.cs
@@ -37,11 +37,7 @@ namespace WorkflowGen
             ObservabilityUtils.StartMetricsServer();
 
             var builder = Host.CreateDefaultBuilder(args)
-                .ConfigureLogging((hostingContext, config) =>
-                {
-                    config.ClearProviders();
-                    config.AddJsonConsole();
-                })
+                .ConfigureTestInfraLogging()
                 .ConfigureServices(services =>
                 {
                     services.AddDaprWorkflow(options =>

--- a/workflow-gen/WorkflowRunner.cs
+++ b/workflow-gen/WorkflowRunner.cs
@@ -63,18 +63,18 @@ namespace WorkflowGen
                         instanceId: orderId,
                         workflowComponent: DaprWorkflowComponent);
 
-                    this.logger.LogInformation("Your workflow has started. Here is the status of the workflow: {0}", state.RuntimeStatus);
+                    this.logger.LogInformation("Your workflow has started. Here is the status of the workflow: {Status}", state.RuntimeStatus);
 
                     state = await Client.WaitForWorkflowCompletionAsync(
                         instanceId: orderId,
                         workflowComponent: DaprWorkflowComponent);
 
-                    this.logger.LogInformation("Workflow Status: {0}", state.RuntimeStatus);
+                    this.logger.LogInformation("Workflow Status: {Status}", state.RuntimeStatus);
 
                 }
                 catch (Exception ex)
                 {
-                    this.logger.LogError("Caught {0}", ex.ToString());
+                    this.logger.LogError(ex, "Caught {Exception}", ex);
                     ExecutionFailureCount.Inc();
                 }
             }

--- a/workflow-gen/WorkflowRunner.cs
+++ b/workflow-gen/WorkflowRunner.cs
@@ -30,19 +30,11 @@ namespace WorkflowGen
         private readonly ILogger<WorkflowRunner> logger;
 
 
-        public WorkflowRunner([FromServices] DaprClient client, int counter)
+        public WorkflowRunner([FromServices] DaprClient client, int counter, ILogger<WorkflowRunner> logger)
         {
             this.Client = client;
             this.Counter = counter;
-            var loggerFactory = LoggerFactory.Create(builder =>
-            {
-                builder
-                    .AddFilter("Microsoft", LogLevel.Warning)
-                    .AddFilter("System", LogLevel.Warning)
-                    .AddConsole();
-            });
-
-            this.logger = loggerFactory.CreateLogger<WorkflowRunner>();
+            this.logger = logger;
         }
 
         internal async void Execute(Object stateInfo)


### PR DESCRIPTION
# Description

Makes the logging of the individual infrastructure test apps more consistent by:

 - Using `ILogger` instead of `Console.WriteLine()`
 - Using structured log entries rather than interpolated strings
 - Use a single, common, logging configuration
 - Use JSON-based log entries to ease creation of back-end queries

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
