### PR TITLE
Enable Dapr profiling in all applications.

### DIFF
--- a/deploy/aks/apps/feed-generator-deploy.bicep
+++ b/deploy/aks/apps/feed-generator-deploy.bicep
@@ -53,6 +53,7 @@ resource appsDeployment_feedGeneratorApp 'apps/Deployment@v1' = {
         annotations: {
           'dapr.io/enabled': 'true'
           'dapr.io/app-id': 'feed-generator'
+          'dapr.io/enable-profiling': 'true'
           'dapr.io/log-as-json': 'true'
           'prometheus.io/scrape': 'true'
           'prometheus.io/port': '9988'

--- a/deploy/aks/apps/hashtag-actor-deploy.bicep
+++ b/deploy/aks/apps/hashtag-actor-deploy.bicep
@@ -31,6 +31,7 @@ resource appsDeployment_hashtagActorApp 'apps/Deployment@v1' = {
           'dapr.io/enabled': 'true'
           'dapr.io/app-id': 'hashtag-actor'
           'dapr.io/app-port': '3000'
+          'dapr.io/enable-profiling': 'true'
           'dapr.io/log-as-json': 'true'
         }
       }

--- a/deploy/aks/apps/hashtag-counter-deploy.bicep
+++ b/deploy/aks/apps/hashtag-counter-deploy.bicep
@@ -54,6 +54,7 @@ resource appsDeployment_hashtagCounterApp 'apps/Deployment@v1' = {
           'dapr.io/enabled': 'true'
           'dapr.io/app-id': 'hashtag-counter'
           'dapr.io/app-port': '3000'
+          'dapr.io/enable-profiling': 'true'
           'dapr.io/log-as-json': 'true'
           'prometheus.io/scrape': 'true'
           'prometheus.io/port': '9988'

--- a/deploy/aks/apps/message-analyzer-deploy.bicep
+++ b/deploy/aks/apps/message-analyzer-deploy.bicep
@@ -54,6 +54,7 @@ resource appsDeployment_messageAnalyzerApp 'apps/Deployment@v1' = {
           'dapr.io/enabled': 'true'
           'dapr.io/app-id': 'message-analyzer'
           'dapr.io/app-port': '80'
+          'dapr.io/enable-profiling': 'true'
           'dapr.io/log-as-json': 'true'
           'prometheus.io/scrape': 'true'
           'prometheus.io/port': '9988'

--- a/deploy/aks/apps/pubsub-workflow-deploy.bicep
+++ b/deploy/aks/apps/pubsub-workflow-deploy.bicep
@@ -54,6 +54,7 @@ resource appsDeployment_pubsubWorkflowApp 'apps/Deployment@v1' = {
           'dapr.io/enabled': 'true'
           'dapr.io/app-id': 'pubsub-workflow'
           'dapr.io/app-port': '3000'
+          'dapr.io/enable-profiling': 'true'
           'dapr.io/log-as-json': 'true'
           'prometheus.io/scrape': 'true'
           'prometheus.io/port': '9988'

--- a/deploy/aks/apps/snapshot-deploy.bicep
+++ b/deploy/aks/apps/snapshot-deploy.bicep
@@ -54,6 +54,7 @@ resource appsDeployment_snapshotApp 'apps/Deployment@v1' = {
           'dapr.io/enabled': 'true'
           'dapr.io/app-id': 'snapshot'
           'dapr.io/app-port': '3000'
+          'dapr.io/enable-profiling': 'true'
           'dapr.io/log-as-json': 'true'
           'prometheus.io/scrape': 'true'
           'prometheus.io/port': '9988'

--- a/deploy/aks/apps/validation-worker-deploy.bicep
+++ b/deploy/aks/apps/validation-worker-deploy.bicep
@@ -53,6 +53,7 @@ resource appsDeployment_validationWorkerApp 'apps/Deployment@v1' = {
         annotations: {
           'dapr.io/enabled': 'true'
           'dapr.io/app-id': 'validation-worker'
+          'dapr.io/enable-profiling': 'true'
           'dapr.io/log-as-json': 'true'
           'prometheus.io/scrape': 'true'
           'prometheus.io/port': '9988'

--- a/deploy/aks/apps/workflow-gen-deploy.bicep
+++ b/deploy/aks/apps/workflow-gen-deploy.bicep
@@ -53,6 +53,7 @@ resource appsDeployment_workflowGenApp 'apps/Deployment@v1' = {
         annotations: {
           'dapr.io/enabled': 'true'
           'dapr.io/app-id': 'workflow-gen'
+          'dapr.io/enable-profiling': 'true'
           'dapr.io/log-as-json': 'true'
           'prometheus.io/scrape': 'true'
           'prometheus.io/port': '9988'

--- a/longhaul-test/feed-generator-deploy.yml
+++ b/longhaul-test/feed-generator-deploy.yml
@@ -37,6 +37,7 @@ spec:
       annotations:
         dapr.io/enabled: "true"
         dapr.io/app-id: "feed-generator"
+        dapr.io/enable-profiling: "true"
         dapr.io/log-as-json: "true"
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9988'        

--- a/longhaul-test/hashtag-actor-deploy.yml
+++ b/longhaul-test/hashtag-actor-deploy.yml
@@ -22,6 +22,7 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "hashtag-actor"
         dapr.io/app-port: "3000"
+        dapr.io/enable-profiling: "true"
         dapr.io/log-as-json: "true"
     spec:
       containers:

--- a/longhaul-test/hashtag-counter-deploy.yml
+++ b/longhaul-test/hashtag-counter-deploy.yml
@@ -38,6 +38,7 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "hashtag-counter"
         dapr.io/app-port: "3000"
+        dapr.io/enable-profiling: "true"
         dapr.io/log-as-json: "true"
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9988'  

--- a/longhaul-test/message-analyzer-deploy.yml
+++ b/longhaul-test/message-analyzer-deploy.yml
@@ -38,6 +38,7 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "message-analyzer"
         dapr.io/app-port: "80"
+        dapr.io/enable-profiling: "true"
         dapr.io/log-as-json: "true"
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9988'        

--- a/longhaul-test/pubsub-workflow-deploy.yml
+++ b/longhaul-test/pubsub-workflow-deploy.yml
@@ -40,6 +40,7 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "pubsub-workflow"
         dapr.io/app-port: "3000"
+        dapr.io/enable-profiling: "true"
         dapr.io/log-as-json: "true"
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9988'  

--- a/longhaul-test/snapshot-deploy.yml
+++ b/longhaul-test/snapshot-deploy.yml
@@ -38,6 +38,7 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "snapshot"
         dapr.io/app-port: "3000"
+        dapr.io/enable-profiling: "true"
         dapr.io/log-as-json: "true"
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9988'        

--- a/longhaul-test/validation-worker-deploy.yml
+++ b/longhaul-test/validation-worker-deploy.yml
@@ -37,6 +37,7 @@ spec:
       annotations:
         dapr.io/enabled: "true"
         dapr.io/app-id: "validation-worker"
+        dapr.io/enable-profiling: "true"
         dapr.io/log-as-json: "true"
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9988'        

--- a/longhaul-test/workflow-gen-deploy.yml
+++ b/longhaul-test/workflow-gen-deploy.yml
@@ -37,6 +37,7 @@ spec:
       annotations:
         dapr.io/enabled: "true"
         dapr.io/app-id: "workflow-gen"
+        dapr.io/enable-profiling: "true"
         dapr.io/log-as-json: "true"
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9988'        


### PR DESCRIPTION
# Description

During a recent goroutine leak issue, it was noticed that
we don't have profiling enabled by default for dapr in
the longhaul cluster. This PR addresses this.


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: _none_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
