### PR TITLE
Document how to regain control of Dapr on AKS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Using Helm or `dapr init -k` directly to manage, upgrade or uninstall Dapr on yo
 If you want to fully control Dapr setup on your cluster, you need to uninstall the extension first:
 
 ```bash
-az k8s-extension delete --resource-group ${resourceGroup} --cluster-name ${clusterName} --cluster-type managedClusters --name ${clusterName}-dapr-ext
+az k8s-extension delete --yes --resource-group ${resourceGroup} --cluster-name ${clusterName} --cluster-type managedClusters --name ${clusterName}-dapr-ext
 ```
 
 


### PR DESCRIPTION
# Description


Our AKS Bicep templates offer a convenient way to quickly start up an
AKS cluster running our longhaul applications for E2E testing. However,
this approach puts some constraints on the user's ability to control
the installed Dapr setup.

This PR documents how to circumvent these limitations.


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: none

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [X] Extended the documentation
