### PR TITLE
Modify the default longhaul clusters' names.

### DIFF
--- a/deploy/aks/parameters-longhaul-release.json
+++ b/deploy/aks/parameters-longhaul-release.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "clusterName": {
-      "value": "aks-release-longhaul"
+      "value": "aks-longhaul-release"
     },
     "shortClusterPrefixId": {
       "value": "rel"

--- a/deploy/aks/parameters-longhaul-weekly.json
+++ b/deploy/aks/parameters-longhaul-weekly.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "clusterName": {
-      "value": "aks-weekly-longhaul"
+      "value": "aks-longhaul-weekly"
     },
     "shortClusterPrefixId": {
       "value": "wek"


### PR DESCRIPTION
# Description

Move the purpose of the longhaul to a suffix to make it
more clear when hosting multiple LH in the same subscription or
resource group.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: none

## Testing done

Deployed a new cluster using the new template:

```bash
export SUBSCRIPTION_TO_BE_USED=<insert the target subscription UUID here>
export resourceGroup=aks-longhaul-release
export location=eastus

az account clear && az login --output=none && az account set --subscription ${SUBSCRIPTION_TO_BE_USED} && \
az group create --name ${resourceGroup} --location ${location} && \
az deployment group create --resource-group ${resourceGroup} --template-file ./deploy/aks/main.bicep --parameters deploy/aks/parameters-longhaul-release.json
```

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
