### PR TITLE
add dapr components crawler to test-crawler

### DIFF
--- a/.github/workflows/dapr-e2e-tests-crawler.yml
+++ b/.github/workflows/dapr-e2e-tests-crawler.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest  
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
-      OUTPUT_TARGET: "log.txt"
     steps:  
     - name: Checkout code  
       uses: actions/checkout@v3
@@ -33,9 +32,14 @@ jobs:
     - name: Run Script
       run: python3 test-crawler/__init__.py
 
+    - name: Compress logs
+      if: always()
+      run: |
+        tar -cvf test-crawler/result.tar test-crawler/tests.txt test-crawler/components.txt
+
     - name: Upload results
       if: always()
       uses: actions/upload-artifact@master
       with:
         name: "result" 
-        path: ${{ env.OUTPUT_TARGET }}
+        path: "test-crawler/result.tar"

--- a/test-crawler/__init__.py
+++ b/test-crawler/__init__.py
@@ -3,24 +3,13 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
-from global_settings import REPO, WORKFLOW_NAME, ACCESS_TOKEN, OUTPUT_TARGET
+from global_settings import REPO, WORKFLOW_NAME, ACCESS_TOKEN
 from workflow_scan import WorkFlowScaner
-
 
 if __name__ == "__main__":
     workflow_scaner = WorkFlowScaner(REPO, WORKFLOW_NAME, ACCESS_TOKEN)
-    print(
-        f"Dapr E2E Tests Crawler start. \nREPO : {REPO}  WORKFLOW_NAME : {WORKFLOW_NAME}"
-    )
+    print(f"Dapr E2E Tests Crawler start. \nREPO : {REPO}  WORKFLOW_NAME : {WORKFLOW_NAME}")
     workflow_scaner.scan_workflow()
 
-    pass_rate_string = f"\nPass rate of {WORKFLOW_NAME} is " + "{:.2%}\n".format(
-        workflow_scaner.get_pass_rate()
-    )
-    print(pass_rate_string)
-
-    with open(OUTPUT_TARGET, "w") as file:
-        file.write(pass_rate_string + "\n")
-
-    print("\nFailure Workflow crawling start:")
+    print("Failure Workflow crawling start:")
     workflow_scaner.list_failure_case()

--- a/test-crawler/components_crawler.py
+++ b/test-crawler/components_crawler.py
@@ -1,0 +1,71 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+import base64
+import yaml
+import requests
+from global_settings import GITHUB_API_PARAMETER
+
+
+class ComponentsCrawler:
+    def __init__(self, repo, access_token):
+        self.repo = repo
+        self.access_token = access_token
+        self.headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Authorization": f"token {access_token}",
+        }
+        self.app_components_dict = {}
+
+    def scan_components(self):
+        print("\nstart to scan components.\n")
+        url = f"https://api.github.com/repos/{self.repo}/contents/tests/config/"
+        response = requests.get(url, headers=self.headers, params=GITHUB_API_PARAMETER)
+        content = response.json()
+        for file in content:
+            print("\nscanning " + file["name"] + "...")
+            try:
+                file_url = url + file["name"]
+                response = requests.get(
+                    file_url, headers=self.headers, params=GITHUB_API_PARAMETER
+                )
+                content = response.json()["content"]
+                yaml_string = base64.b64decode(content).decode("utf-8")
+
+                yaml_split_string = yaml_string.split("---")
+                for s in yaml_split_string:
+                    if len(s):
+                        data = yaml.safe_load(s)
+
+                        if (data is not None) and ("kind" in data):
+                            if data["kind"] != "Component":
+                                print("it is not about component, skip")
+                                continue
+
+                            components_name = data["spec"]["type"]
+                            if "scopes" in data:
+                                for name in data["scopes"]:
+                                    if name not in self.app_components_dict:
+                                        self.app_components_dict[name] = []
+                                    self.app_components_dict[name].append(
+                                        components_name
+                                    )
+                                    print("app " + name + " is added.")
+                            else:
+                                print(
+                                    "No scope is specified for component "
+                                    + components_name
+                                    + ", skip"
+                                )
+                        else:
+                            print("it is not a k8s api yaml, skip.")
+            except:
+                print("Fail to parse " + file["name"] + ", skip.")
+
+        for key in self.app_components_dict:
+            self.app_components_dict[key] = set(self.app_components_dict[key])
+
+        return self.app_components_dict

--- a/test-crawler/failure_log_crawler.py
+++ b/test-crawler/failure_log_crawler.py
@@ -9,7 +9,7 @@ import json
 import xml.etree.ElementTree as ET
 import zipfile
 from io import BytesIO
-from global_settings import OUTPUT_TARGET
+from global_settings import TESTS_OUTPUT_TARGET, COMPONENTS_OUTPUT_TARGET
 
 
 class TestCaseInfo:
@@ -50,14 +50,17 @@ class FailureLogCrawler:
         }
         self.fail_testcase_dict = {}
         self.fail_testcase_dict_sorted_list = []
+        self.workflow_with_no_artifact = []
 
-    def crawl(self, failure_id, workflow_len):
+    def crawl_failure_workflow(self, failure_id, workflow_len):
         failure_id_len = len(failure_id)
         for index, id in enumerate(failure_id):
             print(
-                f"({index+1}/{failure_id_len}) crawling failure workflow... workflow id is "
+                f"({index+1}/{failure_id_len}) crawling failure workflow "
                 + str(id)
+                + "..."
             )
+
             url = (
                 f"https://api.github.com/repos/{self.repo}/actions/runs/{id}/artifacts"
             )
@@ -67,12 +70,17 @@ class FailureLogCrawler:
             except:
                 print("JSON decode error occured when get artifacts.")
                 continue
-            for artifact in artifacts:
-                if (
-                    artifact["name"] == "linux_amd64_e2e.json"
-                    or artifact["name"] == "windows_amd64_e2e.json"
-                ):
-                    self.parse_artifact(artifact, id)
+
+            if len(artifacts) == 0:
+                print("workflow " + str(id) + " does not upload any artifacts, skip.")
+                self.workflow_with_no_artifact.append(id)
+            else:
+                for artifact in artifacts:
+                    if (
+                        artifact["name"] == "linux_amd64_e2e.json"
+                        or artifact["name"] == "windows_amd64_e2e.json"
+                    ):
+                        self.parse_artifact(artifact, id)
 
         for v in self.fail_testcase_dict.values():
             v.get_fail_rate(workflow_len)
@@ -98,6 +106,24 @@ class FailureLogCrawler:
         tree = ET.parse(extracted_file)
 
         root = tree.getroot()
+
+        # failures occur in TestMain
+        if root.attrib["failures"] == "1":
+            os = artifact["name"].split("_")[0]
+            name = "TestMain"
+
+            if name in self.fail_testcase_dict:
+                self.fail_testcase_dict[name].update_os(os)
+                self.fail_testcase_dict[name].increase_fail_times()
+            else:
+                testcase_info = TestCaseInfo(name, os)
+                self.fail_testcase_dict[name] = testcase_info
+
+                latest_url = f"https://github.com/{self.repo}/actions/runs/{id}"
+                self.fail_testcase_dict[name].set_latest_url(latest_url)
+
+            return
+
         for testsuite in root:
             failures = int(testsuite.attrib["failures"])
             if failures:
@@ -116,8 +142,7 @@ class FailureLogCrawler:
                         self.fail_testcase_dict[name].set_latest_url(latest_url)
 
     def list_failure_testcase(self):
-        print("\nFailed Test Cases:")
-        with open(OUTPUT_TARGET, "a") as file:
+        with open(TESTS_OUTPUT_TARGET, "a") as file:
             for case in self.fail_testcase_dict_sorted_list:
                 fali_rate_string = (
                     "Fail Rate: "
@@ -133,5 +158,30 @@ class FailureLogCrawler:
                     + str(case.latest_url)
                     + "\n"
                 )
-                print(fali_rate_string)
                 file.write(fali_rate_string + "\n")
+
+            file.write("\nWorkflows without any artifact: \n")
+            for idx, id in enumerate(self.workflow_with_no_artifact):
+                file.write(f"{idx}: https://github.com/{self.repo}/actions/runs/{id}\n")
+
+        print("tests result output completed")
+
+    def list_failure_components(self, components_tests_dict):
+        with open(COMPONENTS_OUTPUT_TARGET, "w") as file:
+            for component, tests in components_tests_dict.items():
+                file.write(component + ":\n")
+                for test in tests:
+                    if test in self.fail_testcase_dict:
+                        pass_rate = 1 - self.fail_testcase_dict[test].fail_rate
+                    else:
+                        pass_rate = 1
+                    file.write(
+                        "Pass Rate: "
+                        + "{:.2%}".format(float(pass_rate))
+                        + "     "
+                        + "Test Case: "
+                        + test
+                        + "\n"
+                    )
+                file.write("\n")
+        print("components result output completed.")

--- a/test-crawler/failure_log_crawler.py
+++ b/test-crawler/failure_log_crawler.py
@@ -104,29 +104,13 @@ class FailureLogCrawler:
             sys.stderr.write(f"Error occurred when parse {artifact_name}, skiped")
             return
         tree = ET.parse(extracted_file)
-
         root = tree.getroot()
 
-        # failures occur in TestMain
-        if root.attrib["failures"] == "1":
-            os = artifact["name"].split("_")[0]
-            name = "TestMain"
-
-            if name in self.fail_testcase_dict:
-                self.fail_testcase_dict[name].update_os(os)
-                self.fail_testcase_dict[name].increase_fail_times()
-            else:
-                testcase_info = TestCaseInfo(name, os)
-                self.fail_testcase_dict[name] = testcase_info
-
-                latest_url = f"https://github.com/{self.repo}/actions/runs/{id}"
-                self.fail_testcase_dict[name].set_latest_url(latest_url)
-
-            return
-
+        failures_count = 0
         for testsuite in root:
             failures = int(testsuite.attrib["failures"])
             if failures:
+                failures_count += failures
                 fail_testcases = testsuite.findall("testcase")
                 for fail_testcase in fail_testcases[:failures]:
                     os = artifact["name"].split("_")[0]
@@ -140,6 +124,21 @@ class FailureLogCrawler:
 
                         latest_url = f"https://github.com/{self.repo}/actions/runs/{id}"
                         self.fail_testcase_dict[name].set_latest_url(latest_url)
+
+        # failures occur in TestMain
+        if root.attrib["failures"] == "1" and failures_count== 0:
+            os = artifact["name"].split("_")[0]
+            name = "TestMain"
+
+            if name in self.fail_testcase_dict:
+                self.fail_testcase_dict[name].update_os(os)
+                self.fail_testcase_dict[name].increase_fail_times()
+            else:
+                testcase_info = TestCaseInfo(name, os)
+                self.fail_testcase_dict[name] = testcase_info
+
+                latest_url = f"https://github.com/{self.repo}/actions/runs/{id}"
+                self.fail_testcase_dict[name].set_latest_url(latest_url)
 
     def list_failure_testcase(self):
         with open(TESTS_OUTPUT_TARGET, "a") as file:
@@ -160,9 +159,10 @@ class FailureLogCrawler:
                 )
                 file.write(fali_rate_string + "\n")
 
-            file.write("\nWorkflows without any artifact: \n")
-            for idx, id in enumerate(self.workflow_with_no_artifact):
-                file.write(f"{idx}: https://github.com/{self.repo}/actions/runs/{id}\n")
+            if len(self.workflow_with_no_artifact):
+                file.write("\nWorkflows without any artifact: \n")
+                for idx, id in enumerate(self.workflow_with_no_artifact):
+                    file.write(f"{idx}: https://github.com/{self.repo}/actions/runs/{id}\n")
 
         print("tests result output completed")
 

--- a/test-crawler/global_settings.py
+++ b/test-crawler/global_settings.py
@@ -18,5 +18,8 @@ ACCESS_TOKEN = os.getenv("GITHUB_TOKEN")
 # Parameters brought when accessing github API
 GITHUB_API_PARAMETER = {"per_page": "100"}
 
-# Target to output logs
-OUTPUT_TARGET = "log.txt"
+# Target to output crawl result of tests
+TESTS_OUTPUT_TARGET = "tests.txt"
+
+# Target to output crawl result of components
+COMPONENTS_OUTPUT_TARGET = "components.txt"

--- a/test-crawler/requirements.pip
+++ b/test-crawler/requirements.pip
@@ -1,1 +1,2 @@
-requests
+requestsrequests
+pyyaml

--- a/test-crawler/workflow_scan.py
+++ b/test-crawler/workflow_scan.py
@@ -142,5 +142,3 @@ class WorkFlowScaner:
 
         for k, _ in self.components_tests_dict.items():
             self.components_tests_dict[k] = sorted(set(self.components_tests_dict[k]))
-
-        print("test")

--- a/test-crawler/workflow_scan.py
+++ b/test-crawler/workflow_scan.py
@@ -5,8 +5,13 @@
 
 import requests
 import json
-from global_settings import GITHUB_API_PARAMETER
+import sys
+import zipfile
+import re
+from io import BytesIO
+from global_settings import GITHUB_API_PARAMETER, TESTS_OUTPUT_TARGET
 from failure_log_crawler import FailureLogCrawler
+from components_crawler import ComponentsCrawler
 
 
 class WorkFlowScaner:
@@ -24,14 +29,17 @@ class WorkFlowScaner:
         self.success_num = 0
         self.failure_num = 0
         self.failure_id = []
-        self.crawler = FailureLogCrawler(repo, access_token)
+        self.failure_log_crawler = FailureLogCrawler(repo, access_token)
+        self.components_crawler = ComponentsCrawler(repo, access_token)
+        self.test_app_dict = {}
+        self.components_tests_dict = {}
 
     def scan_workflow(self):
         url = f"https://api.github.com/repos/{self.repo}/actions/workflows/{self.workflow_name}/runs"
         response = requests.get(url, headers=self.headers, params=GITHUB_API_PARAMETER)
         runs = json.loads(response.text)["workflow_runs"]
 
-        # ingore workflows triggered manually
+        # ingore the workflows triggered manually
         scheduled_runs = [r for r in runs if r["event"] == "schedule"]
         self.runs_len = len(scheduled_runs)
         print(f"Successfully get {self.runs_len} scheduled runs")
@@ -42,6 +50,9 @@ class WorkFlowScaner:
             else:
                 if run["conclusion"] == "success":
                     self.success_num += 1
+                    # get all components of each test in first success workflow
+                    if self.success_num == 1:
+                        self.get_components_tests_dict(run["id"])
                 elif run["conclusion"] == "failure":
                     self.failure_num += 1
                     self.failure_id.append(run["id"])
@@ -50,10 +61,86 @@ class WorkFlowScaner:
             f"{self.in_progress_num} runs are still in progress, {self.success_num} runs success and {self.failure_num} runs fail"
         )
 
+        pass_rate_string = f"Pass rate of {self.workflow_name} is " + "{:.2%}\n".format(
+            self.get_pass_rate()
+        )
+
+        with open(TESTS_OUTPUT_TARGET, "w") as file:
+            file.write(pass_rate_string + "\n")
+        print(pass_rate_string)
+
     def get_pass_rate(self):
         pass_rate = self.success_num / self.runs_len
         return pass_rate
 
     def list_failure_case(self):
-        self.crawler.crawl(self.failure_id, self.runs_len)
-        self.crawler.list_failure_testcase()
+        self.failure_log_crawler.crawl_failure_workflow(self.failure_id, self.runs_len)
+        self.failure_log_crawler.list_failure_testcase()
+        self.failure_log_crawler.list_failure_components(self.components_tests_dict)
+
+    def get_test_app_name(self, id):
+        print(f"getting app names in workflow {id}")
+        url = f"https://api.github.com/repos/{self.repo}/actions/runs/{id}/artifacts"
+        response = requests.get(url, headers=self.headers)
+        try:
+            artifacts = response.json()["artifacts"]
+        except:
+            print("JSON decode error occured when get artifacts.")
+        for artifact in artifacts:
+            if artifact["name"] == "linux_amd64_e2e.json":
+                url = artifact["archive_download_url"]
+                artifact_name = artifact["name"]
+                print("downloading artifact " + artifact_name)
+
+                response = requests.get(url, headers=self.headers)
+                try:
+                    zip_file = zipfile.ZipFile(BytesIO(response.content))
+                    extracted_file = zip_file.extract("test_report_e2e.json")
+                except:
+                    sys.stderr.write(
+                        f"Error occurred when parse {artifact_name}, skiped"
+                    )
+                    return
+
+                pattern_app_name = r'github.com/dapr/dapr/tests/e2e/(.*?)".*?\\"AppName\\":\\"(.*?)\\",'
+                pattern_test_name = (
+                    r'github.com/dapr/dapr/tests/e2e/(.*?)".*?=== RUN   (.*?)\\n"'
+                )
+                with open(extracted_file, "r") as f:
+                    content = f.read()
+                    matches_app_name = re.findall(pattern_app_name, content)
+                    matched_test_name = re.findall(pattern_test_name, content)
+
+                app_dict = {}
+                for m in matches_app_name:
+                    if m[0] not in app_dict:
+                        app_dict[m[0]] = []
+                    app_dict[m[0]].append(m[1])
+
+                test_dict = {}
+                for m in matched_test_name:
+                    test_dict[m[1]] = m[0]
+
+                for k, v in test_dict.items():
+                    self.test_app_dict[k] = set(app_dict[v])
+
+        if not self.test_app_dict:
+            print('artifact "linux_amd64_e2e.json" is not existed.')
+
+    def get_components_tests_dict(self, id):
+        app_components_dict = self.components_crawler.scan_components()
+        self.get_test_app_name(id)
+        for test, apps in self.test_app_dict.items():
+            for app in apps:
+                if app in app_components_dict:
+                    for component in app_components_dict[app]:
+                        if component not in self.components_tests_dict:
+                            self.components_tests_dict[component] = []
+                        self.components_tests_dict[component].append(test)
+                else:
+                    print(f"app {app} is not using dapr components, skip")
+
+        for k, _ in self.components_tests_dict.items():
+            self.components_tests_dict[k] = sorted(set(self.components_tests_dict[k]))
+
+        print("test")


### PR DESCRIPTION
# Description
The following new functions are added to test-crawler in this pr.

**1. List E2E tests for each dapr component.**
It will be listed in following formatter.
```
...
state.azure.cosmosdb:
Pass Rate: 100.00%     Test Case: TestActorActivation
Pass Rate: 100.00%     Test Case: TestActorActivation/Actor_deactivates_due_to_timeout.
Pass Rate: 100.00%     Test Case: TestActorActivation/Actor_does_not_deactivate_since_there_is_no_timeout.
Pass Rate: 97.44%     Test Case: TestActorFeatures
Pass Rate: 100.00%     Test Case: TestActorFeatures/Actor_concurrency_different_actor_ids.
...

state.postgres:
Pass Rate: 100.00%     Test Case: TestActorActivation
Pass Rate: 100.00%     Test Case: TestActorActivation/Actor_deactivates_due_to_timeout.
Pass Rate: 100.00%     Test Case: TestActorActivation/Actor_does_not_deactivate_since_there_is_no_timeout.
Pass Rate: 97.44%     Test Case: TestActorFeatures
Pass Rate: 100.00%     Test Case: TestActorFeatures/Actor_concurrency_different_actor_ids.
Pass Rate: 100.00%     Test Case: TestActorFeatures/Actor_concurrency_same_actor_id.
Pass Rate: 100.00%     Test Case: TestActorFeatures/Actor_fails_over_to_another_hostname.
...

```

**2. Show workflows that did not generate any test logs**

```
...
Workflows without any artifact: 
0: https://github.com/dapr/dapr/actions/runs/6414198198
1: https://github.com/dapr/dapr/actions/runs/6301376989
2: https://github.com/dapr/dapr/actions/runs/6298580586
3: https://github.com/dapr/dapr/actions/runs/6296122715
4: https://github.com/dapr/dapr/actions/runs/6294452525
5: https://github.com/dapr/dapr/actions/runs/6292975025
6: https://github.com/dapr/dapr/actions/runs/6289716020
7: https://github.com/dapr/dapr/actions/runs/6286547576

```

**3. Fix several bugs**
- failures about parsing yaml file
- missing catching when TestMain fails


# Additional information
For more details, please refer to the [original repo](https://github.com/MregXN/Dapr-E2E-Tests-Crawler) and running [wokrflow](https://github.com/MregXN/Dapr-E2E-Tests-Crawler/actions/runs/6463181891).

