### PR TITLE
Update workflows for external sub clusters.

### DIFF
--- a/.github/workflows/dapr-deploy.yml
+++ b/.github/workflows/dapr-deploy.yml
@@ -3,22 +3,24 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
-name: deploy-dapr-runtime
+name: deploy-longhaul-release
 
 on:
   push:
     branches:
       - master
+  workflow_dispatch:
+
 jobs:
   deploy:
     name: update dapr runtime on release longhaul cluster
     runs-on: ubuntu-latest
     env:
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
-      DAPR_RUNTIME_VER: 1.12.0-rc.6
+      DAPR_RUNTIME_VER: 1.12.0
       DAPR_NAMESPACE: dapr-system
-      TEST_CLUSTER_NAME: dapr-release-longhaul
-      TEST_RESOURCE_GROUP: dapr-test
+      TEST_CLUSTER_NAME: aks-longhaul-release
+      TEST_RESOURCE_GROUP: aks-longhaul-release
       HELMVER: v3.7.2
       # Test applications-specific settings
       APP_NAMESPACE: longhaul-test

--- a/.github/workflows/dapr-longhaul-weekly.yml
+++ b/.github/workflows/dapr-longhaul-weekly.yml
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-name: dapr-longhaul-weekly
+name: deploy-longhaul-weekly
 
 on:
   schedule:
@@ -20,7 +20,7 @@ on:
 
 jobs:
   test-nightly:
-    name: update dapr runtime
+    name: update dapr runtime with the head of master and run longhaul tests
     runs-on: ubuntu-latest
     env:
       KUBECTLVER: v1.19.3
@@ -38,8 +38,8 @@ jobs:
       DAPR_NAMESPACE: dapr-system
       DAPR_MONITORING: dapr-monitoring
       DAPR_COMPONENTS: dapr-components
-      TEST_CLUSTER: daprnightly
-      TEST_RESOURCE_GROUP: dapr-test
+      TEST_CLUSTER: aks-longhaul-weekly
+      TEST_RESOURCE_GROUP: aks-longhaul-weekly
       DAPR_CHECKOUT_REPO: dapr/dapr
       DAPR_CHECKOUT_REF: refs/heads/master
       APP_NAMESPACE: longhaul-test
@@ -132,47 +132,10 @@ jobs:
       - name: Create component namespace, if it doesn't exist
         run: |
           kubectl get namespace | grep ${{ env.DAPR_COMPONENTS }} || kubectl create namespace ${{ env.DAPR_COMPONENTS }}
-      - name: Check for redis
-        if: env.TEST_CLUSTER != ''
-        run: |
-          helm list -n ${{ env.DAPR_COMPONENTS }} | grep dapr-redis && echo "REDIS_PRESENT=true" >> $GITHUB_ENV || echo "Redis not present."
-      - name: Start redis if not present
-        if: env.REDIS_PRESENT != 'true'
-        run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo update
-          helm install dapr-redis bitnami/redis --namespace ${{ env.DAPR_COMPONENTS }} --wait
-          kubectl delete secret dapr-redis -n ${{ env.APP_NAMESPACE }} --ignore-not-found
-          kubectl get secret dapr-redis -n ${{ env.DAPR_COMPONENTS }} -o yaml | grep -v 'namespace:' | kubectl apply -f - -n ${{ env.APP_NAMESPACE }}
-      - name: Check for kafka
-        if: env.TEST_CLUSTER != ''
-        run: |
-          helm list -n ${{ env.DAPR_COMPONENTS }} | grep dapr-kafka && echo "KAFKA_PRESENT=true" >> $GITHUB_ENV || echo "Kafka not present."
-      - name: Start kafka if not present
-        if: env.KAFKA_PRESENT != 'true'
-        run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo update
-          helm install dapr-kafka bitnami/kafka --wait --namespace ${{ env.DAPR_COMPONENTS }}
       # Deploy all longhaul tests/components
       - name: Create app namespace, if it doesn't exist
         run: |
           kubectl get namespace | grep ${{ env.APP_NAMESPACE }} || kubectl create namespace ${{ env.APP_NAMESPACE }}
-      - name: Apply secret access roles # Required to access k8s in the non-standard namespace.
-        if: env.TEST_CLUSTER != ''
-        working-directory: ./longhaul
-        run: |
-          kubectl apply -f ./longhaul-test/secret-access-role.yml -n ${{ env.APP_NAMESPACE }}
-          kubectl apply -f ./longhaul-test/secret-access-role-binding.yml -n ${{ env.APP_NAMESPACE }}
-      - name: Deploy components
-        if: env.TEST_CLUSTER != ''
-        working-directory: ./longhaul
-        run: |
-          kubectl apply -f ./longhaul-test/azure-nightly-keyvault.yml -n ${{ env.APP_NAMESPACE }}
-          kubectl apply -f ./longhaul-test/azure-service-bus-pubsub.yml -n ${{ env.APP_NAMESPACE }}
-          kubectl apply -f ./longhaul-test/azure-storagequeue-binding.yaml -n ${{ env.APP_NAMESPACE }}
-          kubectl apply -f ./longhaul-test/redis-pubsub.yaml -n ${{ env.APP_NAMESPACE }}
-          kubectl apply -f ./longhaul-test/azure-cosmosdb-statestore.yaml -n ${{ env.APP_NAMESPACE }}
       - name: Deploy test applications
         if: env.TEST_CLUSTER != ''
         working-directory: ./longhaul


### PR DESCRIPTION
This commit updates the workflows to use the clusters configured
in the OSS subscription. Those clusters were created as documented
in #167.

Those clusters live in distinct subscription and have distinct names
from the current ones -- hence the need to update the workflows.

Additionally, because those clusters use Bicep-configure Azure-hosted
state store, binding and pubsub components, there is no need to
configure Redis, Kafka or setup individual components.

Signed-off-by: Tiago Alves Macambira <tmacam@burocrata.org>

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
