### PR TITLE
Bumps the longhauls to 1.13.2 (and .net packages to 1.13.0 stable from rc)

### DIFF
--- a/.github/workflows/dapr-deploy.yml
+++ b/.github/workflows/dapr-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
-      DAPR_RUNTIME_VER: 1.13.1
+      DAPR_RUNTIME_VER: 1.13.2
       DAPR_NAMESPACE: dapr-system
       TEST_CLUSTER_NAME: aks-longhaul-release
       TEST_RESOURCE_GROUP: aks-longhaul-release

--- a/.github/workflows/dapr-deploy.yml
+++ b/.github/workflows/dapr-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
-      DAPR_RUNTIME_VER: 1.13.0-rc.6
+      DAPR_RUNTIME_VER: 1.13.1
       DAPR_NAMESPACE: dapr-system
       TEST_CLUSTER_NAME: aks-longhaul-release
       TEST_RESOURCE_GROUP: aks-longhaul-release
@@ -52,7 +52,7 @@ jobs:
         uses: azure/setup-kubectl@v3
         with:
           version: ${{ env.KUBECTLVER }}
-        id: install      
+        id: install
       - name: Deploy test applications
         working-directory: ./longhaul
         run: |

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,9 +1,9 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Dapr.Client" Version="1.13.0-rc03" />
-    <PackageVersion Include="Dapr.AspNetCore" Version="1.13.0-rc03" />
-    <PackageVersion Include="Dapr.Actors.AspNetCore" Version="1.13.0-rc03" />
-    <PackageVersion Include="Dapr.Workflow" Version="1.13.0-rc03" />
+    <PackageVersion Include="Dapr.Client" Version="1.13.0" />
+    <PackageVersion Include="Dapr.AspNetCore" Version="1.13.0" />
+    <PackageVersion Include="Dapr.Actors.AspNetCore" Version="1.13.0" />
+    <PackageVersion Include="Dapr.Workflow" Version="1.13.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageVersion Include="prometheus-net" Version="3.5.0" />


### PR DESCRIPTION
# Description

Bumps the longhauls to 1.13.2 (and .net packages to 1.13.0 stable from rc)

https://github.com/dapr/dapr/releases/tag/v1.13.2

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [x] ~~Created~~/updated tests
* [ ] Extended the documentation
