### PR TITLE
Fixes path in workflow

### DIFF
--- a/.github/workflows/dapr-deploy.yml
+++ b/.github/workflows/dapr-deploy.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Read versions from files
         id: read_version
         run: |
-          echo "DAPR_RUNTIME_VER=$(cat config/dapr_runtime.version)" >> $GITHUB_ENV
-          echo "DAPR_CLI_VER=$(cat config/dapr_cli.version)" >> $GITHUB_ENV
+          echo "DAPR_RUNTIME_VER=$(cat longhaul/config/dapr_runtime.version)" >> $GITHUB_ENV
+          echo "DAPR_CLI_VER=$(cat longhaul/config/dapr_cli.version)" >> $GITHUB_ENV
       - name: Set up Dapr CLI
         run: wget -q ${{ env.DAPR_INSTALL_URL }} -O - | /bin/bash -s ${{ env.DAPR_CLI_VER }}
       - name: Set up Helm ${{ env.HELMVER }}


### PR DESCRIPTION
CI runs failed because of a wrong path of the config file, considering the repo is being checked out in the `longhaul` directory